### PR TITLE
- Move logic for user expansion of config file

### DIFF
--- a/ec2deprecateimg
+++ b/ec2deprecateimg
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2015 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This file is part of ec2imgutils
 #
@@ -66,7 +66,7 @@ argparse.add_argument(
 )
 argparse.add_argument(
     '-f', '--file',
-    default=os.path.expanduser('~') + os.sep + '.ec2utils.conf',
+    default=os.sep.join(['~','.ec2utils.conf'])
     dest='configFilePath',
     help='Path to configuration file, default ~/.ec2utils.conf (Optional)',
     metavar='CONFIG_FILE'
@@ -229,7 +229,7 @@ if (
     sys.exit(1)
 
 
-config_file = args.configFilePath
+config_file = os.path.expanduser(args.configFilePath)
 config = None
 if not os.path.isfile(config_file):
     print('Configuration file "%s" not found.' % config_file)

--- a/ec2publishimg
+++ b/ec2publishimg
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2015 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This file is part of ec2imgutils
 #
@@ -62,7 +62,7 @@ argparse.add_argument(
 )
 argparse.add_argument(
     '-f', '--file',
-    default=os.path.expanduser('~') + os.sep + '.ec2utils.conf',
+    default=os.sep.join(['~','.ec2utils.conf'])
     dest='configFilePath',
     help='Path to configuration file, default ~/.ec2utils.conf (Optional)',
     metavar='CONFIG_FILE'
@@ -159,7 +159,7 @@ if (
     sys.exit(1)
 
 
-config_file = args.configFilePath
+config_file = os.path.expanduser(args.configFilePath)
 config = None
 if not os.path.isfile(config_file):
     print('Configuration file "%s" not found.' % config_file)

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -104,7 +104,7 @@ argparse.add_argument(
 )
 argparse.add_argument(
     '-f', '--file',
-    default=os.path.expanduser('~') + os.sep + '.ec2utils.conf',
+    default=os.sep.join(['~','.ec2utils.conf'])
     dest='configFilePath',
     help='Path to configuration file, default ~/.ec2utils.conf (Optional)',
     metavar='CONFIG_FILE'
@@ -285,7 +285,7 @@ if '--version' in sys.argv:
     sys.exit(0)
 
 args = argparse.parse_args()
-config_file = args.configFilePath
+config_file = os.path.expanduser(args.configFilePath)
 config = None
 if not os.path.isfile(config_file):
     print('Configuration file "%s" not found.' % config_file)


### PR DESCRIPTION
  + This allows the user to skip entering the full config file path if the
    alternate config file is located in the users home directory