### PR TITLE
ec2uploadimg: set AssociatePublicIpAddress

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -723,7 +723,7 @@ class EC2ImageUploader(EC2ImgUtils):
                         'DeviceIndex': 0,
                         'AssociatePublicIpAddress': True,
                         'SubnetId': self.vpc_subnet_id,
-                        'Groups' :self.security_group_ids.split(',')
+                        'Groups': self.security_group_ids.split(',')
                     }
                 ]
             )['Instances'][0]

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -721,7 +721,7 @@ class EC2ImageUploader(EC2ImgUtils):
                 NetworkInterfaces=[
                     {
                         'DeviceIndex': 0,
-                        'AssociatePublicIpAddress': True,
+                        'AssociatePublicIpAddress': not self.use_private_ip,
                         'SubnetId': self.vpc_subnet_id,
                         'Groups': self.security_group_ids.split(',')
                     }
@@ -738,7 +738,7 @@ class EC2ImageUploader(EC2ImgUtils):
                 NetworkInterfaces=[
                     {
                         'DeviceIndex': 0,
-                        'AssociatePublicIpAddress': True,
+                        'AssociatePublicIpAddress': not self.use_private_ip,
                         'SubnetId': self.vpc_subnet_id
                     }
                 ]

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -718,8 +718,14 @@ class EC2ImageUploader(EC2ImgUtils):
                 KeyName=self.ssh_key_pair_name,
                 InstanceType=self.launch_ins_type,
                 Placement={'AvailabilityZone': self.zone},
-                SubnetId=self.vpc_subnet_id,
-                SecurityGroupIds=self.security_group_ids.split(',')
+                NetworkInterfaces=[
+                    {
+                        'DeviceIndex': 0,
+                        'AssociatePublicIpAddress': True,
+                        'SubnetId': self.vpc_subnet_id,
+                        'Groups' :self.security_group_ids.split(',')
+                    }
+                ]
             )['Instances'][0]
         else:
             instance = self._connect().run_instances(
@@ -729,7 +735,13 @@ class EC2ImageUploader(EC2ImgUtils):
                 KeyName=self.ssh_key_pair_name,
                 InstanceType=self.launch_ins_type,
                 Placement={'AvailabilityZone': self.zone},
-                SubnetId=self.vpc_subnet_id,
+                NetworkInterfaces=[
+                    {
+                        'DeviceIndex': 0,
+                        'AssociatePublicIpAddress': True,
+                        'SubnetId': self.vpc_subnet_id
+                    }
+                ]
             )['Instances'][0]
 
         self.instance_ids.append(instance['InstanceId'])


### PR DESCRIPTION
Explicitly set AssociatePublicIpAddress when running helper instance since
instances created in non-default VPCs do not have a public IP address by
default.