### PR TITLE
Fix cleanup with --use-root-swap img upload

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -1055,6 +1055,7 @@ class EC2ImageUploader(EC2ImgUtils):
                 True
             )
 
+        self._clean_up()
         return ami['ImageId']
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
When using --use-root-swap we see `DependencyViolations` during
`SecurityGroup` cleanup, because the corresponding VM(s) wasn't terminated.
Never the less, the image was successful created.
So terminate/cleanup the corresponding VM(s) in
`create_image_use_root_swap()` before retrieving created AMI id.

Failure looks like:
```
linux:~/ec2_upload # ec2uploadimg --access-id "$AWS_ACCESS_KEY_ID" -s "$AWS_SECRET_ACCESS_KEY" \
> --backing-store ssd --grub2 --machine 'x86_64' \
> -n 'cfconrad-test-openqa-SLES12-SP5-EC2.x86_64-0.9.1-On-Demand-Build1.53.raw.xz' \
> --virt-type hvm --sriov-support --use-root-swap \
> --verbose --regions 'eu-central-1' \
> --ssh-key-pair 'cfconrad-key' --private-key-file QA_SSH_KEY.pem \
> -d 'cfconrad-test-upload' 'SLES12-SP5-EC2.x86_64-0.9.1-On-Demand-Build1.53.raw.xz'
Successfully created VPC with id vpc-0615d95d220e9c302
Successfully created internet gateway igw-0bcd350dc4eaa04bd
Successfully created route table rtb-0f79fc607a9542927
Successfully created VPC subnet with id subnet-03b52fb84f96eb176
Creating temporary security group
Temporary Security Group Created sg-0137b5607cf55e75c in vpc vpc-0615d95d220e9c302
Successfully allowed incoming SSH port 22 for security group sg-0137b5607cf55e75c in vpc-0615d95d220e9c302
Waiting for instance:  i-09fb76c037177aa3f
.  .  
Waiting for volume creation:  vol-039a9e605fac45c44
.  
Wait for volume attachment
.  
Waiting for volume creation:  vol-0960ac4da39a0df66
.  
Wait for volume attachment
.  
Waiting to obtain instance IP address
.  
Attempt ssh connection
/usr/lib/python3.6/site-packages/paramiko/client.py:837: UserWarning: Unknown ssh-ed25519 host key for 18.185.85.238: b'85772dec7ef796c99c9e8bc7471363f4'
  key.get_name(), hostname, hexlify(key.get_fingerprint())

Formating storage volume
Creating ext3 filesystem on storage volume
Uploading image file:  SLES12-SP5-EC2.x86_64-0.9.1-On-Demand-Build1.53.raw.xz
. . . . . . . . . 
Inflating image:  SLES12-SP5-EC2.x86_64-0.9.1-On-Demand-Build1.53.raw.xz
Dumping raw image to new target root volume
Wait for volume to detach
.  
Wait for volume to detach
.  
Waiting for helper instance to stop
.  .  
Wait for volume to detach
.  
Wait for volume attachment
.  
Creating new image
Waiting for new image creation
.  .  .  .  .  .  .  .  .  .  .  .  .  
Created image:  ami-04f4506e73a480bfb
An error occurred (DependencyViolation) when calling the DeleteSecurityGroup operation: resource sg-0137b5607cf55e75c has a dependent object
```

With this change we get a `0` exit code and output like:
```
Created image:  ami-06b3a87ba4bc3e225
Successfully deleted security group sg-0c2b86f86419e8775
Successfully deleted route from route table rtb-0e0e9917cbbe75ad0
Successfully deleted VPC subnet subnet-05951b96c2e53b62f
Successfully deleted route table rtb-0e0e9917cbbe75ad0
Successfully deleted detached internet gateway igw-0da6fe3494e084b1f
Successfully deleted internet gateway igw-0da6fe3494e084b1f
Successfully deleted VPC vpc-073b8546cd82c88dd
```