### PR TITLE
Tag helper instances.

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -759,10 +759,10 @@ class EC2ImageUploader(EC2ImgUtils):
                         'Tags': [
                             {
                                 'Key': 'Name',
-                                'Value': 'ec2uploadimg-helper-instance',
-                            },
-                        ],
-                    },
+                                'Value': 'ec2uploadimg-helper-instance'
+                            }
+                        ]
+                    }
                 ]
             )['Instances'][0]
         else:
@@ -786,10 +786,10 @@ class EC2ImageUploader(EC2ImgUtils):
                         'Tags': [
                             {
                                 'Key': 'Name',
-                                'Value': 'ec2uploadimg-helper-instance',
-                            },
-                        ],
-                    },
+                                'Value': 'ec2uploadimg-helper-instance'
+                            }
+                        ]
+                    }
                 ]
             )['Instances'][0]
 

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -752,6 +752,17 @@ class EC2ImageUploader(EC2ImgUtils):
                         'SubnetId': self.vpc_subnet_id,
                         'Groups': self.security_group_ids.split(',')
                     }
+                ],
+                TagSpecifications=[
+                    {
+                        'ResourceType': 'instance',
+                        'Tags': [
+                            {
+                                'Key': 'Name',
+                                'Value': 'ec2uploadimg-helper-instance',
+                            },
+                        ],
+                    },
                 ]
             )['Instances'][0]
         else:
@@ -768,6 +779,17 @@ class EC2ImageUploader(EC2ImgUtils):
                         'AssociatePublicIpAddress': not self.use_private_ip,
                         'SubnetId': self.vpc_subnet_id
                     }
+                ],
+                TagSpecifications=[
+                    {
+                        'ResourceType': 'instance',
+                        'Tags': [
+                            {
+                                'Key': 'Name',
+                                'Value': 'ec2uploadimg-helper-instance',
+                            },
+                        ],
+                    },
                 ]
             )['Instances'][0]
 


### PR DESCRIPTION
To identify instances that are started from ec2uploadimg.