### PR TITLE
Migrate to python logging.

### DIFF
--- a/ec2deprecateimg
+++ b/ec2deprecateimg
@@ -196,11 +196,13 @@ argparse.add_argument(
 
 args = argparse.parse_args()
 
+logger = utils.get_logger(args.verbose)
+
 if args.version:
     version_file_name = 'VERSION'
     base_path = os.path.dirname(utils.__file__)
-    version = open(base_path + os.sep + version_file_name, 'r').read()
-    print(version)
+    version = open(base_path + os.sep + version_file_name, 'r').read().strip()
+    logger.info(version)
     sys.exit(0)
 
 # Explicit check required to to the group issue, see comment above
@@ -212,7 +214,7 @@ if (
     error_msg = 'ec2deprecateimg: error: one of the arguments '
     error_msg += '--image-id --image-name --image-name-frag '
     error_msg += '--image-name-match is required'
-    print(error_msg)
+    logger.error(error_msg)
     sys.exit(1)
 
 # Explicit check required to to the group issue, see comment above
@@ -224,19 +226,19 @@ if (
     error_msg = 'ec2deprecateimg: error: one of the arguments '
     error_msg += '--replacement-id --replacement-name '
     error_msg += '--replacement-name-frag --replacement-name-match is required'
-    print(error_msg)
+    logger.error(error_msg)
     sys.exit(1)
 
 
 config_file = os.path.expanduser(args.configFilePath)
 config = None
 if not os.path.isfile(config_file):
-    print('Configuration file "%s" not found.' % config_file)
+    logger.error('Configuration file "%s" not found.' % config_file)
     sys.exit(1)
 try:
     config = utils.get_config(config_file)
 except Exception as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)
 
 access_key = args.accessKey
@@ -248,11 +250,11 @@ if not access_key:
                                            'access_key_id',
                                            '--access-id')
     except EC2AccountException as e:
-        print(format(e), file=sys.stderr)
+        logger.exception(e)
         sys.exit(1)
 
 if not access_key:
-    print('Could not determine account access key', file=sys.stderr)
+    logger.error('Could not determine account access key')
     sys.exit(1)
 
 secret_key = args.secretKey
@@ -264,11 +266,11 @@ if not secret_key:
                                            'secret_access_key',
                                            '--secret-key')
     except EC2AccountException as e:
-        print(format(e), file=sys.stderr)
+        logger.exception(e)
         sys.exit(1)
 
 if not secret_key:
-    print('Could not determine account secret access key', file=sys.stderr)
+    logger.error('Could not determine account secret access key')
     sys.exit(1)
 
 regions = utils.get_regions(args, access_key, secret_key)
@@ -291,13 +293,14 @@ deprecator = ec2depimg.EC2DeprecateImg(
         replacement_image_name_fragment=args.replImgNameFrag,
         replacement_image_name_match=args.replImgNameMatch,
         secret_key=secret_key,
-        verbose=args.verbose)
+        log_callback=logger
+)
 
 for region in regions:
     deprecator.set_region(region)
     try:
         if args.dryRun:
-            print('Dry run, image attributes will not be modified')
+            logger.info('Dry run, image attributes will not be modified')
             deprecator.print_deprecation_info()
         else:
             deprecator.deprecate_images()
@@ -305,14 +308,14 @@ for region in regions:
         errors[region] = format(e)
     except Exception as e:
         if errors:
-            print('Collected errors:', file=sys.stderr)
+            logger.error('Collected errors:')
             for region, error in list(errors.items()):
-                print('Region: %s -> %s' % (region, error), file=sys.stderr)
-        print(format(e), file=sys.stderr)
+                logger.error('Region: %s -> %s' % (region, error))
+        logger.exception(e)
         sys.exit(1)
 
 if errors:
-    print('Errors encountered:', file=sys.stderr)
+    logger.error('Errors encountered:')
     for region, error in list(errors.items()):
-        print('Region: %s -> %s' % (region, error), file=sys.stderr)
+        logger.error('Region: %s -> %s' % (region, error))
     sys.exit(1)

--- a/ec2publishimg
+++ b/ec2publishimg
@@ -140,11 +140,13 @@ argparse.add_argument(
 
 args = argparse.parse_args()
 
+logger = utils.get_logger(args.verbose)
+
 if args.version:
     version_file_name = 'VERSION'
     base_path = os.path.dirname(utils.__file__)
     version = open(base_path + os.sep + version_file_name, 'r').read()
-    print(version)
+    logger.info(version)
     sys.exit(0)
 
 # Explicit check required to to the group issue, see comment above
@@ -156,19 +158,19 @@ if (
     error_msg = 'ec2publishimg: error: one of the arguments '
     error_msg += '--image-id --image-name --image-name-frag '
     error_msg += '--image-name-match is required'
-    print(error_msg, file=sys.stderr)
+    logger.error(error_msg)
     sys.exit(1)
 
 
 config_file = os.path.expanduser(args.configFilePath)
 config = None
 if not os.path.isfile(config_file):
-    print('Configuration file "%s" not found.' % config_file)
+    logger.error('Configuration file "%s" not found.' % config_file)
     sys.exit(1)
 try:
     config = utils.get_config(config_file)
 except Exception as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)
 
 access_key = args.accessKey
@@ -180,11 +182,11 @@ if not access_key:
                                            'access_key_id',
                                            '--access-id')
     except EC2AccountException as e:
-        print(format(e), file=sys.stderr)
+        logger.exception(e)
         sys.exit(1)
 
 if not access_key:
-    print('Could not determine account access key', file=sys.stderr)
+    logger.error('Could not determine account access key')
     sys.exit(1)
 
 secret_key = args.secretKey
@@ -196,11 +198,11 @@ if not secret_key:
                                            'secret_access_key',
                                            '--secret-key')
     except EC2AccountException as e:
-        print(format(e), file=sys.stderr)
+        logger.exception(e)
         sys.exit(1)
 
 if not secret_key:
-    print('Could not determine account secret access key', file=sys.stderr)
+    logger.error('Could not determine account secret access key')
     sys.exit(1)
 
 regions = utils.get_regions(args, access_key, secret_key)
@@ -212,7 +214,7 @@ if (
 ):
     msg = 'Expecting "image", "none", or comma separated list of 12 digit AWS '
     msg += 'account numbers as value of --allow-copy'
-    print(msg, file=sys.stderr)
+    logger.error(msg)
     sys.exit(1)
 
 visibility = args.share.lower()
@@ -223,7 +225,7 @@ if (
 ):
     msg = 'Expecting "all", "none", or comma separated list of 12 digit AWS '
     msg += 'account numbers as value of --share'
-    print(msg, file=sys.stderr)
+    logger.error(msg)
     sys.exit(1)
 
 if visibility[-1] == ',':
@@ -237,11 +239,12 @@ publisher = ec2pubimg.EC2PublishImage(
         image_name_fragment=args.pubImgNameFrag,
         image_name_match=args.pubImgNameMatch,
         secret_key=secret_key,
-        verbose=args.verbose,
-        visibility=visibility)
+        visibility=visibility,
+        log_callback=logger
+)
 
 if args.dryRun:
-    print('Dry run, image attributes will not be modified')
+    logger.info('Dry run, image attributes will not be modified')
 try:
     for region in regions:
         publisher.set_region(region)
@@ -250,8 +253,8 @@ try:
         else:
             publisher.publish_images()
 except EC2PublishImgException as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)
 except Exception as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)

--- a/ec2removeimg
+++ b/ec2removeimg
@@ -144,11 +144,13 @@ argparse.add_argument(
 
 args = argparse.parse_args()
 
+logger = utils.get_logger(args.verbose)
+
 if args.version:
     version_file_name = 'VERSION'
     base_path = os.path.dirname(utils.__file__)
     version = open(base_path + os.sep + version_file_name, 'r').read()
-    print(version)
+    logger.info(version)
     sys.exit(0)
 
 # Explicit check required to to the group issue, see comment above
@@ -160,19 +162,19 @@ if (
     error_msg = 'ec2removeimg: error: one of the arguments '
     error_msg += '--image-id --image-name --image-name-frag '
     error_msg += '--image-name-match is required'
-    print(error_msg, file=sys.stderr)
+    logger.error(error_msg)
     sys.exit(1)
 
 
 config_file = os.path.expanduser(args.config_file_path)
 config = None
 if not os.path.isfile(config_file):
-    print('Configuration file "%s" not found.' % config_file)
+    logger.error('Configuration file "%s" not found.' % config_file)
     sys.exit(1)
 try:
     config = utils.get_config(config_file)
 except Exception as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)
 
 access_key = args.access_key
@@ -184,11 +186,11 @@ if not access_key:
                                            'access_key_id',
                                            '--access-id')
     except EC2AccountException as e:
-        print(format(e), file=sys.stderr)
+        logger.exception(e)
         sys.exit(1)
 
 if not access_key:
-    print('Could not determine account access key', file=sys.stderr)
+    logger.error('Could not determine account access key')
     sys.exit(1)
 
 secret_key = args.secret_key
@@ -200,11 +202,11 @@ if not secret_key:
                                            'secret_access_key',
                                            '--secret-key')
     except EC2AccountException as e:
-        print(format(e), file=sys.stderr)
+        logger.exception(e)
         sys.exit(1)
 
 if not secret_key:
-    print('Could not determine account secret access key', file=sys.stderr)
+    logger.error('Could not determine account secret access key')
     sys.exit(1)
 
 regions = utils.get_regions(args, access_key, secret_key)
@@ -219,10 +221,11 @@ remover = ec2rmimg.EC2RemoveImage(
     no_confirm=args.no_confirm,
     remove_all=args.all,
     secret_key=secret_key,
-    verbose=args.verbose)
+    log_callback=logger
+)
 
 if args.dry_run:
-    print('Dry run, the following images would be removed')
+    logger.info('Dry run, the following images would be removed')
 try:
     for region in regions:
         remover.set_region(region)
@@ -231,8 +234,8 @@ try:
         else:
             remover.remove_images()
 except EC2RemoveImgException as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)
 except Exception as e:
-    print(format(e), file=sys.stderr)
+    logger.exception(e)
     sys.exit(1)

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -22,7 +22,6 @@ import boto3
 import os
 import sys
 import signal
-import traceback
 
 import ec2imgutils.ec2utils as utils
 import ec2imgutils.ec2uploadimg as ec2upimg
@@ -30,20 +29,17 @@ from ec2imgutils.ec2imgutilsExceptions import EC2AccountException
 from ec2imgutils.ec2setup import EC2Setup
 
 aborted = False
+logger = None
 
 
-def print_ex(verbose, msg=None):
-    (type, value, tb) = sys.exc_info()
-    if (verbose > 1):
-        traceback.print_exc(file=sys.stderr)
-        if msg:
-            print(msg, file=sys.stderr)
+def print_ex(msg=None):
+    exc_type, value, tb = sys.exc_info()
+    logger.debug(value, exc_info=True)
 
+    if msg:
+        logger.info(msg)
     else:
-        if msg is None:
-            print("{}: {}".format(type.__name__, value), file=sys.stderr)
-        else:
-            print(msg, file=sys.stderr)
+        logger.info("{}: {}".format(exc_type.__name__, value))
 
 
 def signal_handler(signum, frame):
@@ -295,34 +291,36 @@ argparse.add_argument(
     type=int
 )
 
+args = argparse.parse_args()
+logger = utils.get_logger(args.verbose)
+
 if '--version' in sys.argv:
     version_file_name = 'VERSION'
     base_path = os.path.dirname(utils.__file__)
     version = open(base_path + os.sep + version_file_name, 'r').read()
-    print(version)
+    logger.info(version)
     sys.exit(0)
 
-args = argparse.parse_args()
 config_file = os.path.expanduser(args.configFilePath)
 config = None
 if not os.path.isfile(config_file):
-    print('Configuration file "%s" not found.' % config_file)
+    logger.error('Configuration file "%s" not found.' % config_file)
     sys.exit(1)
 
 try:
     config = utils.get_config(config_file)
 except Exception:
-    print_ex(args.verbose)
+    print_ex()
     sys.exit(1)
 
 if not os.path.isfile(args.source):
-    print('Could not find specified image file: %s' % args.source)
+    logger.error('Could not find specified image file: %s' % args.source)
     sys.exit(1)
 
 try:
     utils.check_account_keys(config, args)
 except Exception:
-    print_ex(args.verbose)
+    print_ex()
     sys.exit(1)
 
 access_key = args.accessKey
@@ -334,11 +332,11 @@ if not access_key:
                                            'access_key_id',
                                            '--access-id')
     except EC2AccountException:
-        print_ex(args.verbose)
+        print_ex()
         sys.exit(1)
 
 if not access_key:
-    print('Could not determine account access key', file=sys.stderr)
+    logger.error('Could not determine account access key')
     sys.exit(1)
 
 secret_key = args.secretKey
@@ -350,16 +348,18 @@ if not secret_key:
                                            'secret_access_key',
                                            '--secret-key')
     except EC2AccountException:
-        print_ex(args.verbose)
+        print_ex()
         sys.exit(1)
 
 if not secret_key:
-    print('Could not determine account secret access key', file=sys.stderr)
+    logger.error('Could not determine account secret access key')
     sys.exit(1)
 
 supported_arch = ['arm64', 'i386', 'x86_64']
 if args.arch not in supported_arch:
-    print('Specified architecture must be one of %s' % str(supported_arch))
+    logger.error(
+        'Specified architecture must be one of %s' % str(supported_arch)
+    )
     sys.exit(1)
 
 # All arm64 images must support ENA
@@ -367,7 +367,7 @@ if args.arch not in supported_arch:
 # ENA driver rather than to error out
 if args.arch == 'arm64':
     if not args.ena:
-        print('Enabling ENA support, required by arm64', file=sys.stdout)
+        logger.info('Enabling ENA support, required by arm64')
         args.ena = True
 
 sriov_type = args.sriov
@@ -379,17 +379,18 @@ if virtualization_type == 'para':
     virtualization_type = 'paravirtual'
 
 if sriov_type and virtualization_type != 'hvm':
-    print('SRIOV support is only possible with HVM images', file=sys.stderr)
+    logger.error('SRIOV support is only possible with HVM images')
     sys.exit(1)
 
 if args.ena and virtualization_type != 'hvm':
-    print('ENA is only possible with HVM images', file=sys.stderr)
+    logger.error('ENA is only possible with HVM images')
     sys.exit(1)
 
 if args.amiID and args.runningID:
-    msg = 'Specify either AMI ID to start instance or running '
-    msg += ' ID to use already running instance'
-    print(msg, file=sys.stderr)
+    logger.error(
+        'Specify either AMI ID to start instance or running '
+        ' ID to use already running instance'
+    )
     sys.exit(1)
 
 root_volume_size = 10
@@ -401,15 +402,13 @@ if (
     len(regions) > 1 and (args.amiID or args.akiID or args.runningID or
                           args.vpcSubnetId)
    ):
-    print(
-        'Incompatible arguments: multiple regions specified',
-        file=sys.stderr
+    logger.error(
+        'Incompatible arguments: multiple regions specified'
     )
-    print(
-        'Cannot process region unique argument for --ec2-ami,',
-        file=sys.stderr
+    logger.error(
+        'Cannot process region unique argument for --ec2-ami,'
     )
-    print('--instance-id, or --boot-kernel', file=sys.stderr)
+    logger.error('--instance-id, or --boot-kernel')
     sys.exit(1)
 
 try:
@@ -417,8 +416,13 @@ try:
     running_id = args.runningID
     for region in regions:
         try:
-            setup = EC2Setup(access_key, region, secret_key, args.sessionToken,
-                             args.verbose)
+            setup = EC2Setup(
+                access_key,
+                region,
+                secret_key,
+                args.sessionToken,
+                log_callback=logger
+            )
             if not ami_id and not running_id:
                 try:
                     ami_id = utils.get_from_config(args.accountName,
@@ -427,7 +431,7 @@ try:
                                                    'ami',
                                                    '--ec2-ami')
                 except Exception:
-                    print_ex(args.verbose, 'Could not determine helper AMI-ID')
+                    print_ex('Could not determine helper AMI-ID')
                     sys.exit(1)
             bootkernel = args.akiID
             if args.virtType == 'hvm':
@@ -442,8 +446,7 @@ try:
                                                            'g2_aki_x86_64',
                                                            '--boot-kernel')
                     except Exception:
-                        print_ex(args.verbose,
-                                 'Could not find bootkernel in config')
+                        print_ex('Could not find bootkernel in config')
                         sys.exit(1)
                 elif args.arch == 'x86_64':
                     try:
@@ -453,8 +456,7 @@ try:
                                                            'aki_x86_64',
                                                            '--boot-kernel')
                     except Exception:
-                        print_ex(args.verbose,
-                                 'Could not find bootkernel in config')
+                        print_ex('Could not find bootkernel in config')
                         sys.exit(1)
                 elif args.arch == 'i386':
                     try:
@@ -464,28 +466,18 @@ try:
                                                            'aki_i386',
                                                            '--boot-kernel')
                     except Exception:
-                        print_ex(args.verbose,
-                                 'Could not find bootkernel in config')
+                        print_ex('Could not find bootkernel in config')
                         sys.exit(1)
                 elif args.arch == 'arm64' and args.virtType != 'hvm':
-                    print(
-                        'Images for arm64 must use hvm virtualization',
-                        file=sys.stderr
+                    logger.error(
+                        'Images for arm64 must use hvm virtualization'
                     )
                     sys.exit(1)
                 else:
-                    print(
-                        'Could not reliably determine the ',
-                        end=' ',
-                        file=sys.stderr
+                    logger.error(
+                        'Could not reliably determine the bootkernel to use '
+                        'must specify bootkernel, arch (x86_64|i386) or hvm'
                     )
-                    print('bootkernel to use ', file=sys.stderr)
-                    print(
-                        'must specify bootkernel, ',
-                        end=' ',
-                        file=sys.stderr
-                    )
-                    print('arch (x86_64|i386) or hvm', file=sys.stderr)
                     sys.exit(1)
 
             inst_type = args.instType
@@ -512,7 +504,7 @@ try:
                                                       'ssh_key_name',
                                                       '--ssh-key-pair')
             if not key_pair_name:
-                print('Could not determine key pair name', file=sys.stderr)
+                logger.error('Could not determine key pair name')
                 sys.exit(1)
 
             if not ssh_private_key_file:
@@ -525,20 +517,16 @@ try:
                 )
 
             if not ssh_private_key_file:
-                print(
-                    'Could not determine the private ssh key file',
-                    file=sys.stderr
+                logger.error(
+                    'Could not determine the private ssh key file'
                 )
 
             ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
 
             if not os.path.exists(ssh_private_key_file):
-                print(
-                    (
-                         'SSH private key file "%s" does not exist'
-                         % ssh_private_key_file
-                    ),
-                    file=sys.stderr
+                logger.error(
+                    'SSH private key file "%s" does not exist'
+                    % ssh_private_key_file
                 )
                 sys.exit(1)
 
@@ -550,7 +538,7 @@ try:
                                                  'user',
                                                  '--user')
             if not ssh_user:
-                print('Could not determin ssh user to use', file=sys.stderr)
+                logger.error('Could not determin ssh user to use')
                 sys.exit(1)
 
             vpc_subnet_id = args.vpcSubnetId
@@ -569,14 +557,13 @@ try:
                         'subnet_id_%s' % region,
                         '--vpc-subnet-id'
                     )
-                    if args.verbose and vpc_subnet_id:
-                        print('Using VPC subnet: %s' % vpc_subnet_id)
+                    if vpc_subnet_id:
+                        logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
                 except Exception:
-                    if args.verbose:
-                        msg = 'Not using a subnet-id, none given on the '
-                        msg += 'command line and none found in config for '
-                        msg += '"subnet_id_%s" value' % region
-                        print_ex(args.verbose, msg)
+                    msg = 'Not using a subnet-id, none given on the '
+                    msg += 'command line and none found in config for '
+                    msg += '"subnet_id_%s" value' % region
+                    print_ex(msg)
 
             security_group_ids = args.securityGroupIds
             if not security_group_ids and not args.runningID:
@@ -591,15 +578,14 @@ try:
                             'security_group_ids_%s' % region,
                             '--security-group-ids'
                         )
-                        if args.verbose and security_group_ids:
+                        if security_group_ids:
                             msg = 'Using Security Group IDs: %s'
-                            print(msg % security_group_ids)
+                            logger.debug(msg % security_group_ids)
                     except Exception:
-                        if args.verbose:
-                            msg = 'No security group specified in the '
-                            msg += 'configuration, "security_group_ids_%s" or '
-                            msg += 'given on the command line.'
-                            print_ex(args.verbose, msg % region)
+                        msg = 'No security group specified in the '
+                        msg += 'configuration, "security_group_ids_%s" or '
+                        msg += 'given on the command line.'
+                        print_ex(msg % region)
                     if not security_group_ids and vpc_subnet_id:
                         ec2 = boto3.client(
                             aws_access_key_id=access_key,
@@ -648,9 +634,9 @@ try:
                     ssh_timeout=args.sshTimeout,
                     use_grub2=args.grub2,
                     use_private_ip=args.usePrivateIP,
-                    verbose=args.verbose,
                     vpc_subnet_id=vpc_subnet_id,
-                    wait_count=args.waitCount
+                    wait_count=args.waitCount,
+                    log_callback=logger
                 )
 
                 if args.snapOnly:
@@ -663,9 +649,9 @@ try:
                     ami = uploader.create_image(args.source)
                     print('Created image: ', ami)
         except Exception:
-            print_ex(args.verbose)
+            print_ex()
         finally:
             setup.clean_up()
 except Exception:
-    print_ex(args.verbose)
+    print_ex()
     sys.exit(1)

--- a/lib/ec2imgutils/ec2imgutils.py
+++ b/lib/ec2imgutils/ec2imgutils.py
@@ -16,6 +16,7 @@
 # along with ec2imgutils.ase.  If not, see <http://www.gnu.org/licenses/>.
 
 import boto3
+import logging
 
 from ec2imgutils.ec2imgutilsExceptions import EC2ConnectionException
 
@@ -23,11 +24,17 @@ from ec2imgutils.ec2imgutilsExceptions import EC2ConnectionException
 class EC2ImgUtils:
     """Base class for EC2 Image Utilities"""
 
-    def __init__(self):
+    def __init__(self, log_level=logging.INFO, log_callback=None):
 
         self.region = None
         self.session_token = None
-        self.verbose = None
+
+        if log_callback:
+            self.log = log_callback
+        else:
+            logger = logging.getLogger('ec2imgutils')
+            logger.setLevel(log_level)
+            self.log = logger
 
     # ---------------------------------------------------------------------
     def _connect(self):
@@ -82,9 +89,7 @@ class EC2ImgUtils:
         if self.region and self.region == region:
             return True
 
-        if self.verbose:
-            print('Using EC2 region: ', region)
-
+        self.log.debug('Using EC2 region: {}'.format(region))
         self.region = region
 
         return True

--- a/lib/ec2imgutils/ec2utils.py
+++ b/lib/ec2imgutils/ec2utils.py
@@ -232,7 +232,7 @@ def get_logger(verbose):
     else:
         log_level = logging.INFO
 
-    logger = logging.getLogger('obs_img_utils')
+    logger = logging.getLogger('ec2imgutils')
     logger.setLevel(log_level)
 
     console_handler = logging.StreamHandler()

--- a/tests/test_ec2utilsutils.py
+++ b/tests/test_ec2utilsutils.py
@@ -19,6 +19,7 @@
 # <http://www.gnu.org/licenses/>.
 #
 
+import logging
 import os
 import pytest
 
@@ -30,6 +31,9 @@ from ec2imgutils.ec2imgutilsExceptions import (
 
 this_path = os.path.dirname(os.path.abspath(__file__))
 data_path = this_path + os.sep + 'data'
+
+logger = logging.getLogger('ec2imgutils')
+logger.setLevel(logging.INFO)
 
 
 class Turncoat:
@@ -117,7 +121,7 @@ def test_find_images_by_name_find_some():
     image = {}
     image['Name'] = 'testimage-1'
     images.append(image)
-    found_images = ec2utils.find_images_by_name(images, 'testimage-1')
+    found_images = ec2utils.find_images_by_name(images, 'testimage-1', logger)
     assert 2 == len(found_images)
     assert 'testimage-1' == found_images[1]['Name']
 
@@ -133,13 +137,13 @@ def test_find_images_by_name_pending_image():
     image['Status'] = 'pending'
     image['ImageId'] = 'testimage-3'
     images.append(image)
-    ec2utils.find_images_by_name(images, 'testimage-1')
+    ec2utils.find_images_by_name(images, 'testimage-1', logger)
 
 
 def test_find_images_by_name_find_none():
     """Test find_images_by_name finds nothing and does not error"""
     images = _get_test_images()
-    found_images = ec2utils.find_images_by_name(images, 'test')
+    found_images = ec2utils.find_images_by_name(images, 'test', logger)
     assert 0 == len(found_images)
 
 
@@ -155,21 +159,33 @@ def test_find_images_by_name_fragment_find_some():
     image = {}
     image['Name'] = 'testimg'
     images.append(image)
-    found_images = ec2utils.find_images_by_name_fragment(images, 'this')
+    found_images = ec2utils.find_images_by_name_fragment(
+        images,
+        'this',
+        logger
+    )
     assert 2 == len(found_images)
 
 
 def test_find_images_by_name_fragment_find_none():
     """Test find_images_by_name_fragment finds nothing and does not error"""
     images = _get_test_images()
-    found_images = ec2utils.find_images_by_name_fragment(images, 'foo')
+    found_images = ec2utils.find_images_by_name_fragment(
+        images,
+        'foo',
+        logger
+    )
     assert 0 == len(found_images)
 
 
 def test_find_images_by_name_regex_match_find_some():
     """Test find_images_by_name_regex_match finds images"""
     images = _get_test_images()
-    found_images = ec2utils.find_images_by_name_regex_match(images, '^test')
+    found_images = ec2utils.find_images_by_name_regex_match(
+        images,
+        '^test',
+        logger
+    )
     assert 2 == len(found_images)
 
 
@@ -177,7 +193,11 @@ def test_find_images_by_name_regex_match_find_none():
     """Test find_images_by_name_regex_match finds  nothing and
        does not error"""
     images = _get_test_images()
-    found_images = ec2utils.find_images_by_name_regex_match(images, '^-1')
+    found_images = ec2utils.find_images_by_name_regex_match(
+        images,
+        '^-1',
+        logger
+    )
     assert 0 == len(found_images)
 
 
@@ -186,7 +206,11 @@ def test_find_images_by_name_regex_match_invalid_re():
     images = _get_test_images()
 
     with pytest.raises(Exception):
-        ec2utils.find_images_by_name_regex_match(images, 't*{2}')
+        ec2utils.find_images_by_name_regex_match(
+            images,
+            't*{2}',
+            logger
+        )
 
 
 def test_generate_config_account_name():


### PR DESCRIPTION
Accept an option to provide a python logging object which is used
to write logs. The CLI binaries inject a console based logger.

All print messages migrated to python based logging except for the
ec2upload status printing which wouldn't output nicely in a file
based log.