### PR TITLE
Add support for uncompressed images

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -952,6 +952,8 @@ class EC2ImageUploader(EC2ImgUtils):
         """Unpack the uploaded image file"""
         if self.aborted:
             return
+        raw_image_file = None
+        files = ''
         if (
                 image_filename.find('.tar') != -1 or
                 image_filename.find('.tbz') != -1 or
@@ -962,8 +964,9 @@ class EC2ImageUploader(EC2ImgUtils):
             files = self._execute_ssh_command(command).split('\r\n')
         elif image_filename[-2:] == 'xz':
             files = [image_filename]
+        elif image_filename[-3:] == 'raw':
+            raw_image_file = image_filename
 
-        raw_image_file = None
         if files:
             # Find the disk image
             for fl in files:


### PR DESCRIPTION
This patch allows an uncompressed image (*.raw) to be
used with ec2uploadimg. This fixes

https://github.com/SUSE-Enceladus/ec2imgutils/issues/38