### PR TITLE
Fix ec2uploadimg when large helper instance used

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -952,6 +952,8 @@ class EC2ImageUploader(EC2ImgUtils):
         """Unpack the uploaded image file"""
         if self.aborted:
             return
+        raw_image_file = None
+        files = ''
         if (
                 image_filename.find('.tar') != -1 or
                 image_filename.find('.tbz') != -1 or
@@ -962,8 +964,9 @@ class EC2ImageUploader(EC2ImgUtils):
             files = self._execute_ssh_command(command).split('\r\n')
         elif image_filename[-2:] == 'xz':
             files = [image_filename]
+        elif image_filename[-3:] == 'raw':
+            raw_image_file = image_filename
 
-        raw_image_file = None
         if files:
             # Find the disk image
             for fl in files:

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -647,7 +647,7 @@ class EC2ImageUploader(EC2ImgUtils):
                 continue
             this_device_size = device['size']
             unit = this_device_size[-1]
-            size = int(this_device_size[:-1])
+            size = float(this_device_size[:-1])
             size_multiplier = 1
             if unit == 'T':
                 size_multiplier = 1024


### PR DESCRIPTION
This patch resolves an issue where a seconday disk is attached
to larger instance sizes and a seconday disk size is non integer.
For example, 139.7G. This size can be declared a float in this case
and this does not effect the outcome.

This closes https://github.com/SUSE-Enceladus/ec2imgutils/issues/46