### PR TITLE
Fix exception with non-integer disks

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -647,7 +647,12 @@ class EC2ImageUploader(EC2ImgUtils):
                 continue
             this_device_size = device['size']
             unit = this_device_size[-1]
-            size = int(this_device_size[:-1])
+            try:
+                size = int(this_device_size[:-1])
+            except ValueError:
+                self.log.info('Skipping non integer sized disk')
+                continue
+
             size_multiplier = 1
             if unit == 'T':
                 size_multiplier = 1024


### PR DESCRIPTION
This patch adds an exception to catch and skip any non-integer sized
diks on the helper instance. The tool only uses integer sized disks
so there is no need to check non-integer sized disks.

This closes https://github.com/SUSE-Enceladus/ec2imgutils/issues/46