### PR TITLE
Add a check for an image to become 'available'

### DIFF
--- a/lib/ec2imgutils/ec2publishimg.py
+++ b/lib/ec2imgutils/ec2publishimg.py
@@ -37,7 +37,8 @@ class EC2PublishImage(EC2ImgUtils):
             secret_key=None,
             visibility='all',
             log_level=logging.INFO,
-            log_callback=None
+            log_callback=None,
+            wait_count=1
     ):
         EC2ImgUtils.__init__(
             self,
@@ -52,6 +53,7 @@ class EC2PublishImage(EC2ImgUtils):
         self.image_name_match = image_name_match
         self.secret_key = secret_key
         self.visibility = visibility
+        self.wait_count = wait_count
 
         if self.visibility == 'all':
             self.publish_msg = '\tPublished: %s\t\t%s'
@@ -156,6 +158,47 @@ class EC2PublishImage(EC2ImgUtils):
         images = self._get_images()
 
         for image in images:
+            if image['State'] != 'available':
+                waiter = self._connect().get_waiter('image_available')
+                loop_count = 0
+                while loop_count < self.wait_count:
+                    self.log.info('Current state of image %s is %s. \
+                                  Waiting up to 10 minutes for it to \
+                                  become available.',
+                                  image['ImageId'], image['State'])
+                    try:
+                        wait_status = waiter.wait(
+                            ImageIds=[image['ImageId']],
+                            Filters=[
+                                {
+                                    'Name': 'state',
+                                    'Values': ['available']
+                                }
+                            ]
+                        )
+                    except Exception:
+                        self.log.error('Skipping image %s as the image state \
+                                       could not be checked',
+                                       image['ImageId'])
+                        continue
+
+                    if wait_status:
+                        if loop_count == self.wait_count:
+                            self.log.info("Skipping image %s as it failed to \
+                                          become 'available",
+                                          image['ImageId'])
+                            continue
+                        else:
+                            loop_count += 1
+                            self.log.info("Image %s is still not 'available'.",
+                                          image['ImageId'])
+                            self.log.info('Entering wait loop number %d of %d',
+                                          loop_count, self.wait_count)
+                    else:
+                        loop_count = self.wait_count
+                        self.log.info("Image %s is now 'available'.",
+                                      image['ImageId'])
+
             if self.visibility == 'all':
                 self._connect().modify_image_attribute(
                     ImageId=image['ImageId'],


### PR DESCRIPTION
This patch uses the AWS waiter to add a check to ec2publishimg to
allow it to wait for an an image to become available before it
publishes the image.

This close https://github.com/SUSE-Enceladus/ec2imgutils/issues/45