### PR TITLE
Add option to create image from an existing snapshot

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -290,6 +290,14 @@ argparse.add_argument(
     metavar='AWS_WAIT_COUNT',
     type=int
 )
+argparse.add_argument(
+    '--use-snapshot',
+    action='store_true',
+    default=False,
+    dest='useSnap',
+    help='Create the image using an existing snapshot that is specified \
+          as the source variable (Optional)'
+)
 
 args = argparse.parse_args()
 logger = utils.get_logger(args.verbose)
@@ -300,6 +308,11 @@ if '--version' in sys.argv:
     version = open(base_path + os.sep + version_file_name, 'r').read()
     logger.info(version)
     sys.exit(0)
+
+if args.useSnap and (args.snapOnly or args.rootSwapMethod):
+    logger.error('The options --use-snapshot cannot be specified \
+                 with --snaponly or --use-root-swap')
+    sys.exit(1)
 
 config_file = os.path.expanduser(args.configFilePath)
 config = None
@@ -313,9 +326,10 @@ except Exception:
     print_ex()
     sys.exit(1)
 
-if not os.path.isfile(args.source):
-    logger.error('Could not find specified image file: %s' % args.source)
-    sys.exit(1)
+if not args.useSnap:
+    if not os.path.isfile(args.source):
+        logger.error('Could not find specified image file: %s' % args.source)
+        sys.exit(1)
 
 try:
     utils.check_account_keys(config, args)
@@ -644,6 +658,9 @@ try:
                     print('Created snapshot: ', snapshot['SnapshotId'])
                 elif args.rootSwapMethod:
                     ami = uploader.create_image_use_root_swap(args.source)
+                    print('Created image: ', ami)
+                elif args.useSnap:
+                    ami = uploader.create_image_from_snapshot(args.source)
                     print('Created image: ', ami)
                 else:
                     ami = uploader.create_image(args.source)

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -1001,6 +1001,24 @@ class EC2ImageUploader(EC2ImgUtils):
         return ami
 
     # ---------------------------------------------------------------------
+    def create_image_from_snapshot(self, source):
+        """Create an AMI (Amazon Machine Image) from the given snapshot"""
+
+        try:
+            response = self._connect().describe_snapshots(SnapshotIds=[source])
+
+        except Exception:
+            self.log.error('Unable to retrieve details for snapshot %s',
+                           source)
+            sys.exit(1)
+
+        snapshot = response['Snapshots'][0]
+        ami = self._register_image(snapshot)
+
+        return ami
+
+    # ---------------------------------------------------------------------
+
     def create_image_use_root_swap(self, source):
         """Creae an AMI (Amazon Machine Image) from the given source using
            the root swap method"""

--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -136,6 +136,9 @@ Specifies the AWS session token. Only necessary when using temporary credentials
 When this argument is set only a snapshot of the uploaded image will be
 created. The snapshot may then be used in a separate operation to register
 an AMI.
+.IP "--use-snapshot"
+When this argument is set the image will be created from an existing snapshot.
+The snapshotID is specified as the source variable.
 .IP "--sriov-support"
 Enable SRIOV support for HVM images. This implies that the appropriate
 driver has to be included in the image.


### PR DESCRIPTION
This patch adds an option to ec2uploadimg to allow an image
to be created from an existing snapshot. A new command line
option, --use-snapshot, provides the ability to specify an
existing Snapshot ID as the source.

Close: https://github.com/SUSE-Enceladus/ec2imgutils/issues/23