### PR TITLE
Add option to get account values from aws credentials

### DIFF
--- a/man/man1/ec2deprecateimg.1
+++ b/man/man1/ec2deprecateimg.1
@@ -37,7 +37,14 @@ The options of the sections are:
 .I ssh_key_name
 and
 .IR ssh_private_key .
-this allows the program to connect to EC2.
+This allows the program to connect to EC2.
+If the access_key_id and/or secret_access_key are not found in
+.IR ~/.ec2utils.conf,
+the search will use the ACCOUNT_NAME to look for a matching section
+[profile ACCOUNT_NAME] in
+.IR ~/.aws/config
+or [ACCOUNT_NAME] in
+.IR ~/.aws/credentials.
 .IP "--access-id AWS_ACCESS_KEY"
 Specifies the AWS access key and overrides the value given for the
 .I account

--- a/man/man1/ec2listimg.1
+++ b/man/man1/ec2listimg.1
@@ -23,7 +23,15 @@ The options of the sections are:
 .I ssh_key_name
 and
 .IR ssh_private_key .
-this allows the program to connect to EC2. Only the
+This allows the program to connect to EC2.
+If the access_key_id and/or secret_access_key are not found in
+.IR ~/.ec2utils.conf,
+the search will use the ACCOUNT_NAME to look for a matching section
+[profile ACCOUNT_NAME] in
+.IR ~/.aws/config
+or [ACCOUNT_NAME] in
+.IR ~/.aws/credentials.
+Only the
 .IR access_key_id
 and
 .IR secret_access_key

--- a/man/man1/ec2publishimg.1
+++ b/man/man1/ec2publishimg.1
@@ -23,6 +23,13 @@ The options of the sections are:
 and
 .IR ssh_private_key .
 These allow the program to connect to EC2.
+If the access_key_id and/or secret_access_key are not found in
+.IR ~/.ec2utils.conf,
+the search will use the ACCOUNT_NAME to look for a matching section
+[profile ACCOUNT_NAME] in
+.IR ~/.aws/config
+or [ACCOUNT_NAME] in
+.IR ~/.aws/credentials.
 .IP "--access-id AWS_ACCESS_KEY"
 Specifies the AWS access key and overrides the value given for the
 .I account

--- a/man/man1/ec2removeimg.1
+++ b/man/man1/ec2removeimg.1
@@ -22,7 +22,15 @@ The options of the sections are:
 .I ssh_key_name
 and
 .IR ssh_private_key .
-this allows the program to connect to EC2. Only the
+This allows the program to connect to EC2.
+If the access_key_id and/or secret_access_key are not found in
+.IR ~/.ec2utils.conf,
+the search will use the ACCOUNT_NAME to look for a matching section
+[profile ACCOUNT_NAME] in
+.IR ~/.aws/config
+or [ACCOUNT_NAME] in
+.IR ~/.aws/credentials.
+Only the 
 .IR access_key_id
 and
 .IR secret_access_key

--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -34,7 +34,14 @@ The options of the sections are
 .I secret_access_key
 .I ssh_key_name
 .I ssh_private_key
-this allows the program to connect to EC2.
+This allows the program to connect to EC2.
+If the access_key_id and/or secret_access_key are not found in
+.IR ~/.ec2utils.conf,
+the search will use the ACCOUNT_NAME to look for a matching section
+[profile ACCOUNT_NAME] in
+.IR ~/.aws/config
+or [ACCOUNT_NAME] in
+.IR ~/.aws/credentials.
 .IP "--access-id AWS_ACCESS_KEY"
 Specifies the AWS access key and overrides the value given for the
 .I account


### PR DESCRIPTION
This patch adds an option to additionally query the
~/.aws/credentials file to retrieve the access_key_id
and secret_access_key. The account specified on the
cli is used to find a match in the credentials file.

Closes: https://github.com/SUSE-Enceladus/ec2imgutils/issues/26