### PR TITLE
ec2utils: use 'version' argparse action for '--version'

### DIFF
--- a/ec2deprecateimg
+++ b/ec2deprecateimg
@@ -188,22 +188,14 @@ argparse.add_argument(
 )
 argparse.add_argument(
     '--version',
-    action='store_true',
-    default=False,
-    dest='version',
+    action='version',
+    version=utils.get_version(),
     help='Program version'
 )
 
 args = argparse.parse_args()
 
 logger = utils.get_logger(args.verbose)
-
-if args.version:
-    version_file_name = 'VERSION'
-    base_path = os.path.dirname(utils.__file__)
-    version = open(base_path + os.sep + version_file_name, 'r').read().strip()
-    logger.info(version)
-    sys.exit(0)
 
 # Explicit check required to to the group issue, see comment above
 if (

--- a/ec2listimg
+++ b/ec2listimg
@@ -103,22 +103,14 @@ argparse.add_argument(
 )
 argparse.add_argument(
     '--version',
-    action='store_true',
-    default=False,
-    dest='version',
+    action='version',
+    version=utils.get_version(),
     help='Program version'
 )
 
 args = argparse.parse_args()
 
 logger = utils.get_logger(args.verbose)
-
-if args.version:
-    version_file_name = 'VERSION'
-    base_path = os.path.dirname(utils.__file__)
-    version = open(base_path + os.sep + version_file_name, 'r').read().strip()
-    logger.info(version)
-    sys.exit(0)
 
 config_file = os.path.expanduser(args.config_file_path)
 config = None

--- a/ec2publishimg
+++ b/ec2publishimg
@@ -130,24 +130,17 @@ argparse.add_argument(
     dest='verbose',
     help='Enable verbose output, default "False"'
 )
+
 argparse.add_argument(
     '--version',
-    action='store_true',
-    default=False,
-    dest='version',
+    action='version',
+    version=utils.get_version(),
     help='Program version'
 )
 
 args = argparse.parse_args()
 
 logger = utils.get_logger(args.verbose)
-
-if args.version:
-    version_file_name = 'VERSION'
-    base_path = os.path.dirname(utils.__file__)
-    version = open(base_path + os.sep + version_file_name, 'r').read()
-    logger.info(version)
-    sys.exit(0)
 
 # Explicit check required to to the group issue, see comment above
 if (

--- a/ec2removeimg
+++ b/ec2removeimg
@@ -136,22 +136,14 @@ argparse.add_argument(
 )
 argparse.add_argument(
     '--version',
-    action='store_true',
-    default=False,
-    dest='version',
+    action='version',
+    version=utils.get_version(),
     help='Program version'
 )
 
 args = argparse.parse_args()
 
 logger = utils.get_logger(args.verbose)
-
-if args.version:
-    version_file_name = 'VERSION'
-    base_path = os.path.dirname(utils.__file__)
-    version = open(base_path + os.sep + version_file_name, 'r').read().strip()
-    logger.info(version)
-    sys.exit(0)
 
 # Explicit check required to to the group issue, see comment above
 if (

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -266,9 +266,8 @@ argparse.add_argument(
     help=help_msg)
 argparse.add_argument(
     '--version',
-    action='store_true',
-    default=False,
-    dest='version',
+    action='version',
+    version=utils.get_version(),
     help='Program version'
 )
 help_msg = 'The ID, starts with "subnet-" of the VPC subnet in which the '
@@ -293,13 +292,6 @@ argparse.add_argument(
 
 args = argparse.parse_args()
 logger = utils.get_logger(args.verbose)
-
-if '--version' in sys.argv:
-    version_file_name = 'VERSION'
-    base_path = os.path.dirname(utils.__file__)
-    version = open(base_path + os.sep + version_file_name, 'r').read()
-    logger.info(version)
-    sys.exit(0)
 
 config_file = os.path.expanduser(args.configFilePath)
 config = None

--- a/lib/ec2imgutils/ec2utils.py
+++ b/lib/ec2imgutils/ec2utils.py
@@ -18,6 +18,7 @@
 import boto3
 import configparser
 import logging
+import os
 import re
 import sys
 
@@ -241,3 +242,11 @@ def get_logger(verbose):
 
     logger.addHandler(console_handler)
     return logger
+
+
+# ----------------------------------------------------------------------------
+def get_version():
+    version_file_name = 'VERSION'
+    base_path = os.path.dirname(__file__)
+    version = open(base_path + os.sep + version_file_name, 'r').read()
+    return version.rstrip('\n')


### PR DESCRIPTION
This avoid erroring out on '--version' in case there are parameters marked as required (currently the case in ec2uploadimg).