### PR TITLE
Remove Traceback when account/key is missing

### DIFF
--- a/lib/ec2imgutils/ec2utils.py
+++ b/lib/ec2imgutils/ec2utils.py
@@ -182,8 +182,11 @@ def get_account_info_from_aws(account, entry):
         except Exception:
             continue
     if not value:
-        msg = 'Could not find %s in aws credentials file for region %s'
-        raise EC2ConfigFileParseException(msg % (entry, account))
+        sys.stdout.write("Unable to determine the %s value from " \
+                         "~/.ec2utils.conf, ~/.aws/config, or " \
+                         "~/.aws/credentials for account/profile %s." \
+                         % entry  % account)
+        exit(1)
 
     return value
 


### PR DESCRIPTION
This patch cleans up the error condition when an account/access key
pair is not found in ec2utils.conf or ~/.aws/* config files. Instead
of a Tracback, the program exits (signal 1) and prints an apporpiate
message.