### PR TITLE
Cleanup Traceback in ec2publishimg and ec2deprecateimg

### DIFF
--- a/ec2deprecateimg
+++ b/ec2deprecateimg
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2018 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This file is part of ec2imgutils
 #
@@ -242,7 +242,7 @@ if not access_key:
                                            'access_key_id',
                                            '--access-id')
     except EC2AccountException as e:
-        logger.exception(e)
+        logger.error(e)
         sys.exit(1)
 
 if not access_key:
@@ -258,7 +258,7 @@ if not secret_key:
                                            'secret_access_key',
                                            '--secret-key')
     except EC2AccountException as e:
-        logger.exception(e)
+        logger.error(e)
         sys.exit(1)
 
 if not secret_key:

--- a/ec2publishimg
+++ b/ec2publishimg
@@ -163,7 +163,7 @@ if not os.path.isfile(config_file):
 try:
     config = utils.get_config(config_file)
 except Exception as e:
-    logger.exception(e)
+    logger.error(e)
     sys.exit(1)
 
 access_key = args.accessKey
@@ -175,7 +175,7 @@ if not access_key:
                                            'access_key_id',
                                            '--access-id')
     except EC2AccountException as e:
-        logger.exception(e)
+        logger.error(e)
         sys.exit(1)
 
 if not access_key:
@@ -191,7 +191,7 @@ if not secret_key:
                                            'secret_access_key',
                                            '--secret-key')
     except EC2AccountException as e:
-        logger.exception(e)
+        logger.error(e)
         sys.exit(1)
 
 if not secret_key:


### PR DESCRIPTION
This patch cleans up some Tracebacks that were triggered
when a reguired argument was missing. Instead of the
Traceback, the program exits with an error and an appropriate message.