### PR TITLE
- Catch additional exception for ssh connection

### DIFF
--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -588,7 +588,7 @@ class EC2ImageUploader(EC2ImgUtils):
                     username=self.inst_user_name,
                     hostname=instance_ip
                 )
-            except Exception:
+            except (Exception, ConnectionResetError):
                 if self.log_level == logging.DEBUG:
                     print('. ', end=' ')
                     sys.stdout.flush()


### PR DESCRIPTION
  + When we try to connect and the instance is not ready, i.e. ssh deamon may
    not be up a ConnectionResetError is trigger which is currently not caught.
    This triggers  the paramiko "...SSH protocol banner[Errno 104]..." message
    and renders upload interrupted. Catching the additonal exception addresses
    the issue.