### PR TITLE
- Support additional EBS storage classes for image creation

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -80,7 +80,7 @@ argparse.add_argument(
     '-B', '--backing-store',
     default='ssd',
     dest='backingStore',
-    help='The backing store type, (mag|ssd), default ssd (Optional)',
+    help='The backing store type, (mag|ssd), or one of the EBS storage IDs',
     metavar='EC2_BACKING_STORE'
 )
 argparse.add_argument(

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -305,8 +305,10 @@ class EC2ImageUploader(EC2ImgUtils):
 
         if self.backing_store == 'mag':
             backing_store = 'standard'
-        else:
+        elif self.backing_store == 'ssd':
             backing_store = 'gp2'
+        else:
+            backing_store = self.backing_store
 
         block_device_map = {
             'DeviceName': root_device_name,

--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -50,7 +50,8 @@ with the
 in the configuration file.
 .IP "-B --backing-store EC2_BACKING_STORE"
 Specifies the backing store type for the AMI to be created. The uploaded
-image is an EBS (Elastic Block Store) image and my be registered as using
+image is an EBS (Elastic Block Store) backed image and my be registered
+as using
 .I SSD
 or
 .I Magnetic
@@ -58,7 +59,16 @@ media as the backing store when being launched. Possible values are
 .I ssd,
 .I mag,
 or
-.I ssd,mag.
+.I one of the known storage classes.
+The generic identifier
+.I ssd
+is mapped to the
+.I gp2
+storage class, and the
+.I mag
+identifier is mapped to the
+.I standard
+storage class.
 .IP "--billing-codes BILLING_CODES"
 Specifies the billing product codes to apply to the image during
 registration. This functionality is restricted to specific accounts


### PR DESCRIPTION
  + Will now accept any of the EBS storage class identifiers such as
    gp3 and io2. The default remains gp2 for backward compatibility reasons.