### PR TITLE
Inclusion of a new parameter (deprecation-date) in the ec2deprecateimage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ to others if the image is shared.
 
 Images are tagged with:
 
-- Deprecated on -> today's date in YYYYMMDD format
-- Removal date -> today's date plus the deprecation period specified
+- Deprecated on -> provided deprecation date or today's date (if no deprecation
+ date is provided) in YYYYMMDD format
+- Removal date -> deprecation date plus the deprecation period specified
 - Replacement image -> The AMI ID and name of the replacement image
 
 The image set as the replacement is removed from the list of potential
@@ -42,7 +43,8 @@ _--image-name-match_ cannot match the replacement image.
 #### Usage
 
 ```
-> ec2deprecateimg --account example --image-name-match v15 --image-virt-type hvm --replacement-name exampleimage_v16
+> ec2deprecateimg --account example --image-name-match v15 --image-virt-type hvm \
+--replacement-name exampleimage_v16 --deprecation_date 20220510
 ```
 
 See the [man pages](man/man1/ec2deprecateimg.1) for more information.

--- a/ec2deprecateimg
+++ b/ec2deprecateimg
@@ -43,9 +43,18 @@ argparse.add_argument(
     help='AWS access key (Optional)',
     metavar='AWS_ACCESS_KEY'
 )
+help_msg = 'The deprecation date, the date the image is considered '
+help_msg += 'deprecated. The default value is today\'s date (Optional)'
+argparse.add_argument(
+    '--deprecation-date',
+    default='',
+    dest='depDate',
+    help=help_msg,
+    metavar='DEPRECATION_DATE'
+)
 help_msg = 'The deprecation period, image will be tagged for removal '
-help_msg += 'on "now + deprecation perion", specified in months, default '
-help_msg += ' is 6 month (Optional)'
+help_msg += 'on "deprecation date + deprecation period", specified in months, '
+help_msg += 'default is 6 month (Optional)'
 argparse.add_argument(
     '-d', '--deprecation-period',
     default=6,
@@ -269,24 +278,28 @@ regions = utils.get_regions(args, access_key, secret_key)
 
 # Collect all the errors to be displayed later
 errors = {}
-
-deprecator = ec2depimg.EC2DeprecateImg(
-        access_key=access_key,
-        deprecation_period=args.depTime,
-        deprecation_image_id=args.depImgID,
-        deprecation_image_name=args.depImgName,
-        deprecation_image_name_fragment=args.depImgNameFrag,
-        deprecation_image_name_match=args.depImgNameMatch,
-        force=args.force,
-        image_virt_type=args.virtType,
-        public_only=args.publicOnly,
-        replacement_image_id=args.replImgID,
-        replacement_image_name=args.replImgName,
-        replacement_image_name_fragment=args.replImgNameFrag,
-        replacement_image_name_match=args.replImgNameMatch,
-        secret_key=secret_key,
-        log_callback=logger
-)
+try:
+    deprecator = ec2depimg.EC2DeprecateImg(
+            access_key=access_key,
+            deprecation_date=args.depDate,
+            deprecation_period=args.depTime,
+            deprecation_image_id=args.depImgID,
+            deprecation_image_name=args.depImgName,
+            deprecation_image_name_fragment=args.depImgNameFrag,
+            deprecation_image_name_match=args.depImgNameMatch,
+            force=args.force,
+            image_virt_type=args.virtType,
+            public_only=args.publicOnly,
+            replacement_image_id=args.replImgID,
+            replacement_image_name=args.replImgName,
+            replacement_image_name_fragment=args.replImgNameFrag,
+            replacement_image_name_match=args.replImgNameMatch,
+            secret_key=secret_key,
+            log_callback=logger
+    )
+except EC2DeprecateImgException as e:
+    logger.exception(e)
+    sys.exit(1)
 
 for region in regions:
     deprecator.set_region(region)

--- a/lib/ec2imgutils/ec2deprecateimg.py
+++ b/lib/ec2imgutils/ec2deprecateimg.py
@@ -31,6 +31,7 @@ class EC2DeprecateImg(EC2ImgUtils):
     def __init__(
             self,
             access_key=None,
+            deprecation_date='',
             deprecation_period=6,
             deprecation_image_id=None,
             deprecation_image_name=None,
@@ -68,7 +69,7 @@ class EC2DeprecateImg(EC2ImgUtils):
         self.replacement_image_name_match = replacement_image_name_match
         self.secret_key = secret_key
 
-        self._set_deprecation_date()
+        self._set_deprecation_date(deprecation_date)
         self._set_deletion_date()
 
         self.replacement_image_tag = None
@@ -173,17 +174,38 @@ class EC2DeprecateImg(EC2ImgUtils):
 
     # ---------------------------------------------------------------------
     def _set_deletion_date(self):
-        """Set the date when the deprecation perios expires"""
-        now = datetime.datetime.now()
-        expire = now + dateutil.relativedelta.relativedelta(
+        """Set the date when the deprecation period expires"""
+        dep_date = None
+        if self.deprecation_date:
+            try:
+                dep_date = datetime.datetime.strptime(
+                    self.deprecation_date, '%Y%m%d')
+            except Exception as e:
+                msg = 'The deprecation date, "%s", is not valid.' \
+                    % self.deprecation_date
+                raise EC2DeprecateImgException(msg) from e
+        else:
+            dep_date = datetime.datetime.now()
+            self._set_deprecation_date('')
+        expire = dep_date + dateutil.relativedelta.relativedelta(
             months=+self.deprecation_period)
         self.deletion_date = self._format_date(expire)
 
     # ---------------------------------------------------------------------
-    def _set_deprecation_date(self):
-        """Set the deprecation day in the YYYYMMDD format"""
-        now = datetime.datetime.now()
-        self.deprecation_date = self._format_date(now)
+    def _set_deprecation_date(self, deprecation_date):
+        """Set the deprecation date provided in the YYYYMMDD format"""
+        dep_date = None
+        if deprecation_date:
+            try:
+                dep_date = datetime.datetime.strptime(
+                    deprecation_date, '%Y%m%d')
+            except Exception as e:
+                msg = 'The deprecation date provided, "%s", is not valid.' \
+                    % deprecation_date
+                raise EC2DeprecateImgException(msg) from e
+        else:
+            dep_date = datetime.datetime.now()
+        self.deprecation_date = self._format_date(dep_date)
 
     # ---------------------------------------------------------------------
     def _set_replacement_image_info(self):

--- a/man/man1/ec2deprecateimg.1
+++ b/man/man1/ec2deprecateimg.1
@@ -14,8 +14,9 @@ tagging mechanism is an implementation based on convention. Tags are not
 sticky, i.e. not visible to others if the image is shared.
 
 Images are tagged with:
-- Deprecated on     -> today's date in YYYYMMDD format
-- Removal date      -> today's date plus the deprecation period specified
+- Deprecated on     -> provided deprecation date (or today's date if no value
+provided) in YYYYMMDD format
+- Removal date      -> deprecation date plus the deprecation period specified
 - Replacement image -> The AMI ID and name of the replacement image
 
 In EC2 a deprecated image is set into a state that makes it invisible to
@@ -55,11 +56,14 @@ Specifies the AWS access key and overrides the value given for the
 with the
 .I access_key_id
 in the configuration file.
+.IP "--deprecation-date YYYYMMDD"
+Specifies the date when the image is considered deprecated. This parameter is
+optional and if it's not provided it will default to the date on which the
+program is executed.
 .IP "-d --deprecation-period NUMBER_OF_MONTHS"
 Specifies the number of months this image will be considered deprecated. After
 the deprecation period expires the image may be removed. The deprecation time
-is added to the date on which the program is executed and forms the value for
-the
+is added to the deprecation date and forms the value for the
 .I Removal date
 tag in the format
 .I YYYYMMDD.

--- a/tests/test_ec2deprecateimg.py
+++ b/tests/test_ec2deprecateimg.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of ec2utils
+#
+# ec2utils is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# ec2utils is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ec2utils. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+import logging
+import pytest
+import datetime
+import dateutil.relativedelta
+
+import ec2imgutils.ec2deprecateimg as ec2depimg
+
+from ec2imgutils.ec2imgutilsExceptions import (
+     EC2DeprecateImgException
+)
+
+
+logger = logging.getLogger('ec2imgutils')
+logger.setLevel(logging.INFO)
+# --------------------------------------------------------------------
+# Test data for deprecation date parameter
+today = datetime.datetime.now()
+today_tag = today.strftime('%Y%m%d')
+one_month_delta = dateutil.relativedelta.relativedelta(months=+1)
+six_month_delta = dateutil.relativedelta.relativedelta(months=+6)
+
+test_depr_date_data = [
+    ("", 1, False, today_tag, (today + one_month_delta).strftime('%Y%m%d')),
+    ("", 6, False, today_tag, (today + six_month_delta).strftime('%Y%m%d')),
+    ("20220707", 6, False, '20220707', '20230107'),
+    ("20221231", 1, False, '20221231', '20230131'),
+    ("20220331", 1, False, '20220331', '20220430'),
+    ("asdf", 6, True, '', ''),
+    ("20220230", 6, True, '', ''),
+    ("2022", 6, True, '', ''),
+]
+
+
+@pytest.mark.parametrize(
+    "depr_date,depr_period,expected_exc,expected_depr_date,expected_del_date",
+    test_depr_date_data
+)
+def test_deprecation_date_parameter(
+    depr_date,
+    depr_period,
+    expected_exc,
+    expected_depr_date,
+    expected_del_date
+):
+    """Test deprecation_date parameter"""
+    if expected_exc:
+        with pytest.raises(EC2DeprecateImgException) as depr_exc:
+            deprecator = ec2depimg.EC2DeprecateImg(
+                access_key='',
+                deprecation_date=depr_date,
+                deprecation_period=depr_period,
+                deprecation_image_id='',
+                deprecation_image_name='',
+                deprecation_image_name_fragment='',
+                deprecation_image_name_match='',
+                force=False,
+                image_virt_type='',
+                public_only=False,
+                replacement_image_id='',
+                replacement_image_name='',
+                replacement_image_name_fragment='',
+                replacement_image_name_match='',
+                secret_key='',
+                log_callback=logger
+            )
+        assert "deprecation date" in str(depr_exc.value)
+        assert depr_date in str(depr_exc.value)
+
+    else:
+        deprecator = ec2depimg.EC2DeprecateImg(
+            access_key='',
+            deprecation_date=depr_date,
+            deprecation_period=depr_period,
+            deprecation_image_id='',
+            deprecation_image_name='',
+            deprecation_image_name_fragment='',
+            deprecation_image_name_match='',
+            force=False,
+            image_virt_type='',
+            public_only=False,
+            replacement_image_id='',
+            replacement_image_name='',
+            replacement_image_name_fragment='',
+            replacement_image_name_match='',
+            secret_key='',
+            log_callback=logger
+        )
+        assert expected_depr_date == deprecator.deprecation_date
+        assert expected_del_date == deprecator.deletion_date


### PR DESCRIPTION

This change aims to include a new parameter (--deprecation-date) in the ec2deprecateimg
script to allow the user to override the default deprecation date (today's).

The topic was tracked under this [Issue 80](https://github.com/SUSE-Enceladus/ec2imgutils/issues/80)

**Considerations**
- As the requested parameter is optional, in case it's not included the behavior is
the one the script already had (defaulting to the script execution date).
- When the parameter provided does not match the expected format (YYYYMMDD) or the date is wrong (Feb 30th for example), the script raises and exception, prints the error message, an exception and exits(1).

**Changes**

- _README.md_ file has been updated with the updated information.
- man page was updated also to include the new param
- _ec2deprecateimg_:
  - The new parameter has been added to the argparse code
  - A new parameter with the deprecation date provided (or empty string if not provided)
  has been added to the initialization of EC2DeprecateImg class
  - As the class initialization can raise an exception (if the provided deprecation-date
  is not correct) the initialization has been included in a try-catch statement.
- _lib/ec2imgutils/ec2deprecateim.py_:
  - _set_deletion_date and _set_deprecation_date have been updated
- Some tests for the date management have been included in a new test file _test_ec2deprecateimg.py_

**Tests completed**
- Tested the installation of the locally generated packages in aws instances with Tumbleweed, Leap 15.3 and SLES 15SP3.
- Deprecated some image with the user providing the date verifying the labels are correct in the image

```
    ec2deprecateimg --account amunoz --deprecation-date 20220909 -d 4 --dry-run --image-id ami-0d7f3cb4ce988fdaf --replacement-id ami-05489e9ee6c50da79 --regions us-east-1 
    Dry run, image attributes will not be modified
    Would deprecate images in region: us-east-1
            Deprecated on 20220909
            Removal date 20230109
            Replacement image ami-05489e9ee6c50da79 -- sle15sp3-micro-v20211213
            Images to deprecate:
                    ID                              Name
                    ami-0d7f3cb4ce988fdaf   sles15sp3-chost-refresh-test
```
  - Upload an image with ec2uploadimgs script (to learn how to do it) and tag the image for deprecation to verify the behavior is correct when the param is not included.

```
    ec2deprecateimg --account amunoz  -d 4 --dry-run --image-id ami-0bb5185717c17af41 --replacement-id ami-0d7f3cb4ce988fdaf --regions us-east-1 
    Dry run, image attributes will not be modified
    Would deprecate images in region: us-east-1
            Deprecated on 20220512
            Removal date 20220912
            Replacement image ami-0d7f3cb4ce988fdaf -- sles15sp3-chost-refresh-test
            Images to deprecate:
                    ID                              Name
                    ami-0bb5185717c17af41   amunoz upload test
```
- Test man page format has no errors