### PR TITLE
Fix bug at ec2deprecatorimg filter function

### DIFF
--- a/lib/ec2imgutils/ec2deprecateimg.py
+++ b/lib/ec2imgutils/ec2deprecateimg.py
@@ -156,6 +156,7 @@ class EC2DeprecateImg(EC2ImgUtils):
                     # cond specified and image not matching, moving on
                     continue
 
+
             # Append the image once to the list if proceeds
             if (
                 self.image_virt_type and
@@ -164,14 +165,19 @@ class EC2DeprecateImg(EC2ImgUtils):
                 should_append_public_only
             ):
                 images.append(image)
-            else if (
+            elif (
                 self.image_virt_type and
                 should_append_virt_type
             ):
                 images.append(image)
-            else if (
+            elif (
                 self.public_only and
                 should_append_public_only
+            ):
+                images.append(image)
+            elif (
+                not self.image_virt_type and
+                not self.public_only
             ):
                 images.append(image)
         return images

--- a/lib/ec2imgutils/ec2deprecateimg.py
+++ b/lib/ec2imgutils/ec2deprecateimg.py
@@ -156,7 +156,8 @@ class EC2DeprecateImg(EC2ImgUtils):
                     # cond specified and image not matching, moving on
                     continue
 
-            # Append the image once to the list if proceeds
+            # Append the image once to the list of images to be processed
+            # if a filter was configured and the image matched it
             if (
                 self.image_virt_type and
                 self.public_only and

--- a/lib/ec2imgutils/ec2deprecateimg.py
+++ b/lib/ec2imgutils/ec2deprecateimg.py
@@ -126,17 +126,23 @@ class EC2DeprecateImg(EC2ImgUtils):
         images = []
         my_images = self._get_owned_images()
         for image in my_images:
+            should_append_virt_type = False
+            should_append_public_only = False
             if filter_replacement_image:
                 if image['ImageId'] == self.replacement_image_id:
                     msg = 'Ignore replacement image as potential target '
                     msg += 'for deprecation.'
                     self.log.debug(msg)
                     continue
+            # Check for virt_type condition if specified
             if self.image_virt_type:
                 if self.image_virt_type == image['VirtualizationType']:
-                    images.append(image)
+                    should_append_virt_type = True
                 else:
+                    # cond specified and image not matching, moving on
                     continue
+
+            # Check for public_only condition if specified
             if self.public_only:
                 launch_attributes = self._connect().describe_image_attribute(
                     ImageId=image['ImageId'],
@@ -145,10 +151,29 @@ class EC2DeprecateImg(EC2ImgUtils):
                 if launch_attributes:
                     launch_permission = launch_attributes[0].get('Group', None)
                 if launch_permission == 'all':
-                    images.append(image)
-                continue
-            images.append(image)
+                    should_append_public_only = True
+                else:
+                    # cond specified and image not matching, moving on
+                    continue
 
+            # Append the image once to the list if proceeds
+            if (
+                self.image_virt_type and
+                self.public_only and
+                should_append_virt_type and
+                should_append_public_only
+            ):
+                images.append(image)
+            else if (
+                self.image_virt_type and
+                should_append_virt_type
+            ):
+                images.append(image)
+            else if (
+                self.public_only and
+                should_append_public_only
+            ):
+                images.append(image)
         return images
 
     # ---------------------------------------------------------------------
@@ -323,9 +348,13 @@ class EC2DeprecateImg(EC2ImgUtils):
         )
         self.log.info('\tDeprecated on {}'.format(self.deprecation_date))
         self.log.info('\tRemoval date {}'.format(self.deletion_date))
-        self.log.info(
-            '\tReplacement image {}'.format(self.replacement_image_tag)
-        )
+        if self.replacement_image_tag:
+            self.log.info(
+                '\tReplacement image {}'.format(self.replacement_image_tag)
+            )
+        else:
+            self.log.info("\tNo replacement image provided")
+
         self.log.info('\tImages to deprecate:\n\t\tID\t\t\t\tName')
         for image in images:
             self.log.info('\t\t%s\t%s' % (image['ImageId'], image['Name']))

--- a/lib/ec2imgutils/ec2deprecateimg.py
+++ b/lib/ec2imgutils/ec2deprecateimg.py
@@ -156,7 +156,6 @@ class EC2DeprecateImg(EC2ImgUtils):
                     # cond specified and image not matching, moving on
                     continue
 
-
             # Append the image once to the list if proceeds
             if (
                 self.image_virt_type and

--- a/tests/test_ec2deprecateimg.py
+++ b/tests/test_ec2deprecateimg.py
@@ -24,10 +24,12 @@ import pytest
 import datetime
 import dateutil.relativedelta
 
+from unittest.mock import patch, MagicMock
+
 import ec2imgutils.ec2deprecateimg as ec2depimg
 
 from ec2imgutils.ec2imgutilsExceptions import (
-     EC2DeprecateImgException
+    EC2DeprecateImgException
 )
 
 logger = logging.getLogger('ec2imgutils')
@@ -107,3 +109,292 @@ def test_deprecation_date_parameter(
         )
         assert expected_depr_date == deprecator.deprecation_date
         assert expected_del_date == deprecator.deletion_date
+
+
+# -----------------------------------------------------------------------------
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._connect')
+def test_deprecate_class_filtering_by_name_match_no_virt_type_no_pub_img(
+    ec2connect_mock,
+    get_owned_imgs_mock,
+    caplog
+):
+    def log_args(**kwargs):
+        logger.info(str(kwargs))
+
+
+    ec2 = MagicMock()
+    ec2.create_tags.return_value = None
+    ec2.create_tags.side_effect = log_args
+    ec2.enable_image_deprecation.return_value = None
+    ec2connect_mock.return_value = ec2
+    get_owned_imgs_mock.return_value = mock_get_owned_images()
+
+    deprecator = ec2depimg.EC2DeprecateImg(
+        access_key='',
+        deprecation_date='20220101',
+        deprecation_period=6,
+        deprecation_image_id='',
+        deprecation_image_name='',
+        deprecation_image_name_fragment='est',
+        deprecation_image_name_match='',
+        force=False,
+        image_virt_type='',
+        public_only=False,
+        replacement_image_id='',
+        replacement_image_name='',
+        replacement_image_name_fragment='',
+        replacement_image_name_match='',
+        secret_key='',
+        log_callback=logger
+    )
+    images = deprecator._get_images_to_deprecate()
+    assert 3 == len(images)
+
+
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._connect')
+def test_deprecate_class_filtering_by_name_match_virt_type_no_pub_img(
+    ec2connect_mock,
+    get_owned_imgs_mock,
+    caplog
+):
+    def log_args(**kwargs):
+        logger.info(str(kwargs))
+
+
+    ec2 = MagicMock()
+    ec2.create_tags.return_value = None
+    ec2.create_tags.side_effect = log_args
+    ec2.enable_image_deprecation.return_value = None
+    ec2connect_mock.return_value = ec2
+    get_owned_imgs_mock.return_value = mock_get_owned_images()
+
+    deprecator = ec2depimg.EC2DeprecateImg(
+        access_key='',
+        deprecation_date='20220101',
+        deprecation_period=6,
+        deprecation_image_id='',
+        deprecation_image_name='',
+        deprecation_image_name_fragment='est',
+        deprecation_image_name_match='',
+        force=False,
+        image_virt_type='hvm',
+        public_only=False,
+        replacement_image_id='',
+        replacement_image_name='',
+        replacement_image_name_fragment='',
+        replacement_image_name_match='',
+        secret_key='',
+        log_callback=logger
+    )
+    images = deprecator._get_images_to_deprecate()
+    assert 1 == len(images)
+    assert "ami-000cc31892067693a" == images[0]['ImageId']
+
+
+
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._connect')
+def test_deprecate_class_filtering_by_name_match_no_virt_type_pub_img(
+    ec2connect_mock,
+    get_owned_imgs_mock,
+    caplog
+):
+    def log_args(**kwargs):
+        logger.info(str(kwargs))
+
+    la1 = {}
+    launchAtt1 = MagicMock()
+    launchAtt1.get.return_value = 'all'
+    la1['LaunchPermissions'] = [launchAtt1]
+
+    la2 = {}
+    launchAtt2 = MagicMock()
+    launchAtt2.get.return_value = 'all'
+    la2['LaunchPermissions'] = [launchAtt1]
+
+    ec2 = MagicMock()
+    ec2.describe_image_attribute.side_effect = [la1, la2, la2]
+    ec2connect_mock.return_value = ec2
+    get_owned_imgs_mock.return_value = mock_get_owned_images()
+
+    deprecator = ec2depimg.EC2DeprecateImg(
+        access_key='',
+        deprecation_date='20220101',
+        deprecation_period=6,
+        deprecation_image_id='',
+        deprecation_image_name='',
+        deprecation_image_name_fragment='est',
+        deprecation_image_name_match='',
+        force=False,
+        image_virt_type='',
+        public_only=True,
+        replacement_image_id='',
+        replacement_image_name='',
+        replacement_image_name_fragment='',
+        replacement_image_name_match='',
+        secret_key='',
+        log_callback=logger
+    )
+    images = deprecator._get_images_to_deprecate()
+    assert 3 == len(images)
+
+
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._connect')
+def test_deprecate_class_filtering_by_name_match_no_virt_type_pub_img2(
+    ec2connect_mock,
+    get_owned_imgs_mock,
+    caplog
+):
+    def log_args(**kwargs):
+        logger.info(str(kwargs))
+
+    la1 = {}
+    launchAtt1 = MagicMock()
+    launchAtt1.get.return_value = 'all'
+    la1['LaunchPermissions'] = [launchAtt1]
+
+    la2 = {}
+    launchAtt2 = MagicMock()
+    launchAtt2.get.return_value = 'NOTall'
+    la2['LaunchPermissions'] = [launchAtt2]
+
+    ec2 = MagicMock()
+    ec2.describe_image_attribute.side_effect = [la1, la2, la2]
+    ec2connect_mock.return_value = ec2
+    get_owned_imgs_mock.return_value = mock_get_owned_images()
+
+    deprecator = ec2depimg.EC2DeprecateImg(
+        access_key='',
+        deprecation_date='20220101',
+        deprecation_period=6,
+        deprecation_image_id='',
+        deprecation_image_name='',
+        deprecation_image_name_fragment='est',
+        deprecation_image_name_match='',
+        force=False,
+        image_virt_type='',
+        public_only=True,
+        replacement_image_id='',
+        replacement_image_name='',
+        replacement_image_name_fragment='',
+        replacement_image_name_match='',
+        secret_key='',
+        log_callback=logger
+    )
+    images = deprecator._get_images_to_deprecate()
+    assert 1 == len(images)
+    assert "ami-000cc31892067693a" == images[0]['ImageId']
+
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
+@patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._connect')
+def test_deprecate_class_filtering_by_name_match_virt_type_pub_img(
+    ec2connect_mock,
+    get_owned_imgs_mock,
+    caplog
+):
+    def log_args(**kwargs):
+        logger.info(str(kwargs))
+
+    la1 = {}
+    launchAtt1 = MagicMock()
+    launchAtt1.get.return_value = 'all'
+    la1['LaunchPermissions'] = [launchAtt1]
+
+    la2 = {}
+    launchAtt2 = MagicMock()
+    launchAtt2.get.return_value = 'NOTall'
+    la2['LaunchPermissions'] = [launchAtt2]
+
+    ec2 = MagicMock()
+    ec2.describe_image_attribute.side_effect = [la2, la1]
+    ec2connect_mock.return_value = ec2
+    get_owned_imgs_mock.return_value = mock_get_owned_images()
+
+    deprecator = ec2depimg.EC2DeprecateImg(
+        access_key='',
+        deprecation_date='20220101',
+        deprecation_period=6,
+        deprecation_image_id='',
+        deprecation_image_name='',
+        deprecation_image_name_fragment='est',
+        deprecation_image_name_match='',
+        force=False,
+        image_virt_type='para',
+        public_only=True,
+        replacement_image_id='',
+        replacement_image_name='',
+        replacement_image_name_fragment='',
+        replacement_image_name_match='',
+        secret_key='',
+        log_callback=logger
+    )
+    images = deprecator._get_images_to_deprecate()
+    assert 1 == len(images)
+    assert "ami-000cc31892067693c" == images[0]['ImageId']
+
+
+
+# --------------------------------------------------------------------
+# Aux functions
+def mock_get_owned_images():
+    myImage1 = {}
+    myImage1["Architecture"] = "x86_64"
+    myImage1["CreationDate"] = "2022-04-11T14:01:58.000Z"
+    myImage1["ImageId"] = "ami-000cc31892067693a"
+    myImage1["Name"] = "testImageName"
+    myI1Ebs = {}
+    myI1Ebs["DeleteOnTermination"] = True
+    myI1Ebs["SnapshotId"] = "snap-000f48a8fa4545e1a"
+    myI1Ebs["VolumeSize"] = 10
+    myI1Ebs["VolumeType"] = "gp3"
+    myI1Ebs["Encrypted"] = False
+    bdmI1 = {}
+    bdmI1["DeviceName"] = "/dev/sda1"
+    bdmI1["Ebs"] = myI1Ebs
+    myImage1["BlockDeviceMappings"] = []
+    myImage1["BlockDeviceMappings"].append(bdmI1)
+    myImage1["VirtualizationType"] = "hvm"
+
+    myImage2 = {}
+    myImage2["Architecture"] = "x86_64"
+    myImage2["CreationDate"] = "2022-04-11T14:01:58.000Z"
+    myImage2["ImageId"] = "ami-000cc31892067693b"
+    myImage2["Name"] = "NotTestImage"
+    myI2Ebs = {}
+    myI2Ebs["DeleteOnTermination"] = True
+    myI2Ebs["SnapshotId"] = "snap-000f48a8fa4545e1b"
+    myI2Ebs["VolumeSize"] = 10
+    myI2Ebs["VolumeType"] = "gp3"
+    myI2Ebs["Encrypted"] = False
+    bdmI2 = {}
+    bdmI2["DeviceName"] = "/dev/sda1"
+    bdmI2["Ebs"] = myI2Ebs
+    myImage2["BlockDeviceMappings"] = []
+    myImage2["BlockDeviceMappings"].append(bdmI2)
+    myImage2["VirtualizationType"] = "para"
+
+    myImage3 = {}
+    myImage3["Architecture"] = "x86_64"
+    myImage3["CreationDate"] = "2022-04-11T14:01:58.000Z"
+    myImage3["ImageId"] = "ami-000cc31892067693c"
+    myImage3["Name"] = "testImageName2"
+    myI3Ebs = {}
+    myI3Ebs["DeleteOnTermination"] = True
+    myI3Ebs["SnapshotId"] = "snap-000f48a8fa4545e1a"
+    myI3Ebs["VolumeSize"] = 10
+    myI3Ebs["VolumeType"] = "gp3"
+    myI3Ebs["Encrypted"] = False
+    bdmI3 = {}
+    bdmI3["DeviceName"] = "/dev/sda1"
+    bdmI3["Ebs"] = myI1Ebs
+    myImage3["BlockDeviceMappings"] = []
+    myImage3["BlockDeviceMappings"].append(bdmI1)
+    myImage3["VirtualizationType"] = "para"
+    myImages = []
+    myImages.append(myImage1)
+    myImages.append(myImage2)
+    myImages.append(myImage3)
+    return myImages

--- a/tests/test_libec2deprecateimg.py
+++ b/tests/test_libec2deprecateimg.py
@@ -122,7 +122,6 @@ def test_deprecate_class_filtering_by_name_match_no_virt_type_no_pub_img(
     def log_args(**kwargs):
         logger.info(str(kwargs))
 
-
     ec2 = MagicMock()
     ec2.create_tags.return_value = None
     ec2.create_tags.side_effect = log_args
@@ -162,7 +161,6 @@ def test_deprecate_class_filtering_by_name_match_virt_type_no_pub_img(
     def log_args(**kwargs):
         logger.info(str(kwargs))
 
-
     ec2 = MagicMock()
     ec2.create_tags.return_value = None
     ec2.create_tags.side_effect = log_args
@@ -191,7 +189,6 @@ def test_deprecate_class_filtering_by_name_match_virt_type_no_pub_img(
     images = deprecator._get_images_to_deprecate()
     assert 1 == len(images)
     assert "ami-000cc31892067693a" == images[0]['ImageId']
-
 
 
 @patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
@@ -288,6 +285,7 @@ def test_deprecate_class_filtering_by_name_match_no_virt_type_pub_img2(
     assert 1 == len(images)
     assert "ami-000cc31892067693a" == images[0]['ImageId']
 
+
 @patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._get_owned_images')
 @patch('ec2imgutils.ec2deprecateimg.EC2DeprecateImg._connect')
 def test_deprecate_class_filtering_by_name_match_virt_type_pub_img(
@@ -334,7 +332,6 @@ def test_deprecate_class_filtering_by_name_match_virt_type_pub_img(
     images = deprecator._get_images_to_deprecate()
     assert 1 == len(images)
     assert "ami-000cc31892067693c" == images[0]['ImageId']
-
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
The function used in the lib/ex2deprecatorimg to apply the 'virtualizationType' and 'public-only' filters to the images was not functioning as per the documentation:
- with the virtualization type you filter the kind of virtualization of the images you want to deprecate
- With the public-only flag you specify if you only want to deprecate public images

In the existing code to filter those:
- If the virtualization type matched, the public-only was not taken into account
- The images could be appended to the list twice and get the deprecation parameters two times (harmless)

The fix assures both conditions are taken into account. Some tests have been included to test all (at least some combinations) scenarios.