### PR TITLE
Return with non-0 exit code on uploadimg failure

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -916,9 +916,10 @@ def upload_image_to_region(
         logger
 ):
     """ Function to upload the image to a region"""
+    errors = 0
+    global setup
+    global uploader
     try:
-        global setup
-        global uploader
         setup = EC2Setup(
             access_key,
             region,
@@ -955,10 +956,20 @@ def upload_image_to_region(
                 logger.info('Created image: {}'.format(str(ami)))
     except EC2UploadImgException as e:
         print_ex(logger, e)
+        errors += 1
     except Exception as e:
         print_ex(logger, e)
+        errors += 1
     finally:
-        setup.clean_up()
+        # avoid unclean termination in case of issues in the cleanup routine
+        try:
+            setup.clean_up()
+        except Exception as e:
+            print_ex(logger, e)
+            errors += 1
+        finally:
+            if errors > 0:
+                sys.exit(1)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1468,6 +1468,51 @@ def test_main_happy_path_other(
     assert "myAmi" in caplog.text
 
 
+@patch('ec2uploadimg.ec2upimg.EC2ImageUploader')
+def test_failed_upload(
+    EC2ImageUploader_mock,
+    caplog
+):
+    ec2I = MagicMock()
+    ec2I.create_image.return_value = 'myAmi'
+    ec2I.create_image.side_effect = ValueError('upload failed (mock)')
+    EC2ImageUploader_mock.return_value = ec2I
+
+    cli_args = [
+        "--account",
+        "testAccName",
+        "--access-id",
+        "testAccId",
+        "--description",
+        "This is a test description for the image",
+        "--ec2-ami",
+        "testAWSAmiId",
+        "--machine",
+        "x86_64",
+        "--name",
+        "testImageName",
+        "--regions",
+        "region1",
+        "--secret-key",
+        "testAwsSecretKey",
+        "--security-group-ids",
+        "testSG1,testSG2",
+        "--ssh-key-pair",
+        "testSshKeyPair",
+        "--type",
+        "testType",
+        "--user",
+        "testUser",
+        "--verbose",
+        "--virt-type",
+        "hvm",
+        data_path + os.sep + 'complete.cfg'
+    ]
+    with pytest.raises(SystemExit) as excinfo:
+        ec2uploadimg.main(cli_args)
+    assert excinfo.value.code != 0
+
+
 @patch('ec2uploadimg.utils.get_from_config')
 def test_main_unable_to_get_access_keys(
     get_from_config_mock


### PR DESCRIPTION
This commit adds an error handling logic to the upload_image procedure
so that the program terminates with a non-0 return code on upload
errors.