### PR TITLE
Includes the option to provide a durable ec2 client to ease testing

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -595,7 +595,7 @@ def get_key_pair_name_and_ssh_private_key_file(
     """
     key_pair_name = args.sshName
     ssh_private_key_file = args.privateKey
-    if(
+    if (
         not key_pair_name and
         not ssh_private_key_file and
         not args.accountName

--- a/lib/ec2imgutils/ec2deprecateimg.py
+++ b/lib/ec2imgutils/ec2deprecateimg.py
@@ -46,12 +46,14 @@ class EC2DeprecateImg(EC2ImgUtils):
             replacement_image_name_match=None,
             secret_key=None,
             log_level=logging.INFO,
-            log_callback=None
+            log_callback=None,
+            ec2_client=None
     ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
-            log_callback=log_callback
+            log_callback=log_callback,
+            ec2_client=ec2_client
         )
 
         self.access_key = access_key

--- a/lib/ec2imgutils/ec2imgutils.py
+++ b/lib/ec2imgutils/ec2imgutils.py
@@ -24,7 +24,12 @@ from ec2imgutils.ec2imgutilsExceptions import EC2ConnectionException
 class EC2ImgUtils:
     """Base class for EC2 Image Utilities"""
 
-    def __init__(self, log_level=logging.INFO, log_callback=None):
+    def __init__(
+        self,
+        log_level=logging.INFO,
+        log_callback=None,
+        ec2_client=None
+    ):
 
         self.region = None
         self.session_token = None
@@ -41,9 +46,15 @@ class EC2ImgUtils:
         except AttributeError:
             self.log_level = self.log.logger.level  # LoggerAdapter
 
+        self.durable_ec2_client = ec2_client
+
     # ---------------------------------------------------------------------
     def _connect(self):
         """Connect to EC2"""
+
+        # Allow dependency injection for easier testing
+        if self.durable_ec2_client:
+            return self.durable_ec2_client
 
         ec2 = None
         if self.region:

--- a/lib/ec2imgutils/ec2listimg.py
+++ b/lib/ec2imgutils/ec2listimg.py
@@ -38,12 +38,14 @@ class EC2ListImage(EC2ImgUtils):
             secret_key=None,
             log_level=logging.INFO,
             log_callback=None,
-            verbose=0
+            verbose=0,
+            ec2_client=None
     ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
-            log_callback=log_callback
+            log_callback=log_callback,
+            ec2_client=ec2_client
         )
 
         self.access_key = access_key

--- a/lib/ec2imgutils/ec2publishimg.py
+++ b/lib/ec2imgutils/ec2publishimg.py
@@ -37,12 +37,14 @@ class EC2PublishImage(EC2ImgUtils):
             secret_key=None,
             visibility='all',
             log_level=logging.INFO,
-            log_callback=None
+            log_callback=None,
+            ec2_client=None
     ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
-            log_callback=log_callback
+            log_callback=log_callback,
+            ec2_client=ec2_client
         )
 
         self.access_key = access_key

--- a/lib/ec2imgutils/ec2removeimg.py
+++ b/lib/ec2imgutils/ec2removeimg.py
@@ -40,12 +40,14 @@ class EC2RemoveImage(EC2ImgUtils):
             remove_all=False,
             secret_key=None,
             log_level=logging.INFO,
-            log_callback=None
+            log_callback=None,
+            ec2_client=None
     ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
-            log_callback=log_callback
+            log_callback=log_callback,
+            ec2_client=ec2_client
         )
 
         self.access_key = access_key

--- a/lib/ec2imgutils/ec2setup.py
+++ b/lib/ec2imgutils/ec2setup.py
@@ -37,12 +37,14 @@ class EC2Setup(EC2ImgUtils):
             secret_key,
             session_token,
             log_level=logging.INFO,
-            log_callback=None
+            log_callback=None,
+            ec2_client=None
     ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
-            log_callback=log_callback
+            log_callback=log_callback,
+            ec2_client=ec2_client
         )
 
         self.access_key = access_key

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -62,12 +62,14 @@ class EC2ImageUploader(EC2ImgUtils):
                  log_level=logging.INFO,
                  log_callback=None,
                  boot_mode=None,
-                 tpm_support=None
+                 tpm_support=None,
+                 ec2_client=None,
                  ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
-            log_callback=log_callback
+            log_callback=log_callback,
+            ec2_client=ec2_client
         )
 
         self.access_key = access_key


### PR DESCRIPTION
Includes the option to provide a boto3.client class that will be reused in the instance.
The intention is to make tests simpler and improve test coverage.