### PR TITLE
Split python 3.6 CI/CD action to ubuntu:20.04 container

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -3,12 +3,37 @@ name: Continuous testing & Linting
 on: [push]
 
 jobs:
-  build:
+  test36:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+    - name: Lint with flake8
+      run: |
+        flake8
+        flake8 ec2*img
+    - name: Test with pytest
+      run: |
+        pytest
+
+  test:
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -595,7 +595,7 @@ def get_key_pair_name_and_ssh_private_key_file(
     """
     key_pair_name = args.sshName
     ssh_private_key_file = args.privateKey
-    if(
+    if (
         not key_pair_name and
         not ssh_private_key_file and
         not args.accountName


### PR DESCRIPTION
Splitting the python3.6 CI/CD actions to an ubuntu 20.04 container, as ubuntu:latest does not have python3.6 interpreter