### PR TITLE
Add man page entry for uefi-preferred

### DIFF
--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -85,11 +85,14 @@ or
 value in the configuration file.
 .IP "--boot-mode"
 Optionally specify the boot mode for the image. Accepted values are
-.I legacy-bios
+.I legacy-bios,
+.I uefi,
 or
-.I uefi .
+.I uefi-preferred .
 If no boot mode is specified the default behavior for the instance type
 applies, uefi for aarch64 instances and bios for x86_64 based instances.
+An image with the uefi-preferred setting will boot using uefi if the instance
+type supports uefi, otherwise it will use bios.
 .IP "-d --description IMAGE_DESCRIPTION"
 Specifies a description for the image. The description will also be used for
 the snapshot.


### PR DESCRIPTION
The uefi-preferred setting was introduced with e27c74385 at that time the man page was not updated. Fixes #104