### PR TITLE
Imds ver

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -150,7 +150,7 @@ def parse_args(args):
         dest='grub2',
         help='The image uses the GRUB2 bootloader (Optional)'
     )
-    help_msg = 'Set he protocol version to be used when instances are '
+    help_msg = 'Set the protocol version to be used when instances are '
     help_msg += 'launched from the image, supported values 2.0/v2.0. '
     help_msg += '(Optional)'
     parser.add_argument(

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -150,6 +150,16 @@ def parse_args(args):
         dest='grub2',
         help='The image uses the GRUB2 bootloader (Optional)'
     )
+    help_msg = 'Set he protocol version to be used when instances are '
+    help_msg += 'launched from the image, supported values 2.0/v2.0. '
+    help_msg += '(Optional)'
+    parser.add_argument(
+        '--imds-support',
+        dest='imdsVersion',
+        help=help_msg,
+        choices=['', '2.0', 'v2.0'],
+        metavar='IMDS_VERSION'
+    )
     parser.add_argument(
         '-i', '--instance-id',
         dest='runningID',
@@ -244,7 +254,7 @@ def parse_args(args):
         metavar='SSH_TIME_OUT',
         type=int
     )
-    help_msg = 'The image supports NitroTPM, supported value 2.0/v2.0'
+    help_msg = 'The image supports NitroTPM, supported values 2.0/v2.0'
     help_msg += ' (Optional)'
     parser.add_argument(
         '--tpm-support',
@@ -897,7 +907,8 @@ def get_uploader(
                 wait_count=args.waitCount,
                 log_callback=logger,
                 boot_mode=args.bootMode,
-                tpm_support=args.tpm
+                tpm_support=args.tpm,
+                imds_support=args.imdsVersion
             )
             return uploader
     except EC2UploadImgException as e:

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -64,7 +64,7 @@ class EC2ImageUploader(EC2ImgUtils):
                  boot_mode=None,
                  tpm_support=None,
                  imds_support=None
-    ):
+                 ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -62,8 +62,9 @@ class EC2ImageUploader(EC2ImgUtils):
                  log_level=logging.INFO,
                  log_callback=None,
                  boot_mode=None,
-                 tpm_support=None
-                 ):
+                 tpm_support=None,
+                 imds_support=None
+    ):
         EC2ImgUtils.__init__(
             self,
             log_level=log_level,
@@ -80,6 +81,7 @@ class EC2ImageUploader(EC2ImgUtils):
         self.image_description = image_description
         self.image_name = image_name
         self.image_virt_type = image_virt_type
+        self.imds_support = imds_support
         self.inst_user_name = inst_user_name
         self.launch_ami_id = launch_ami
         self.launch_ins_type = launch_inst_type
@@ -120,6 +122,11 @@ class EC2ImageUploader(EC2ImgUtils):
         if tpm_support and tpm_support not in tpm_versions:
             raise EC2UploadImgException(
                 'tpm_support must be one of %s' % str(tpm_versions)
+            )
+        imds_versions = ['2.0', 'v2.0']
+        if imds_support and imds_support not in imds_versions:
+            raise EC2UploadImgException(
+                'imds_support must be one of %s' % str(imds_versions)
             )
 
     def abort(self):
@@ -893,6 +900,11 @@ class EC2ImageUploader(EC2ImgUtils):
             if not tpm_version.startswith('v'):
                 tpm_version = 'v%s' % tpm_version
             register_args['TpmSupport'] = tpm_version
+        if self.imds_support:
+            imds_version = self.imds_support
+            if not imds_version.startswith('v'):
+                imds_version = 'v%s' % imds_version
+            register_args['ImdsSupport'] = imds_version
 
         ami = self._connect().register_image(**register_args)
 

--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -118,6 +118,13 @@ Setting this switch will select the
 value from the configuration file or will use the value given with
 .I --boot-kernel
 as the aki ID when a para virtual image is being registered.
+.IP "--imds-support"
+Optionally specify the version for accessing the Instance MetaData Service
+(IMDS). The default is to access the IMDS using the version 1.0 implementation.
+Accepted values are
+.I 2.0
+alternatively prefixed with a
+.I "v".
 .IP "-m --machine ARCH"
 Specifies the architecture for the VM to be created. Supported values
 are

--- a/python3-ec2imgutils.spec
+++ b/python3-ec2imgutils.spec
@@ -26,6 +26,17 @@ License:        GPL-3.0+
 Group:          System/Management
 Url:            https://github.com/SUSE-Enceladus/ec2imgutils
 Source0:        %{upstream_name}-%{version}.tar.bz2
+%if 0%{?sle_version} >= 150400
+Requires:       python311
+Requires:       python311-boto3 >= 1.29.84
+Requires:       python311-dateutil
+Requires:       python311-paramiko >= 2.2.0
+BuildRequires:  python311-boto3 >= 1.29.84
+BuildRequires:  python311-dateutil
+BuildRequires:  python311-pip
+BuildRequires:  python311-setuptools
+BuildRequires:  python311-wheel
+%else
 Requires:       python3
 Requires:       python3-boto3 >= 1.29.84
 Requires:       python3-dateutil
@@ -33,6 +44,7 @@ Requires:       python3-paramiko >= 2.2.0
 BuildRequires:  python3-boto3 >= 1.29.84
 BuildRequires:  python3-dateutil
 BuildRequires:  python3-setuptools
+%endif
 BuildRequires:  python-rpm-macros
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
@@ -67,12 +79,23 @@ A collection of image manipulation utilities for AWS EC2. These include:
 
 %prep
 %setup -q -n %{upstream_name}-%{version}
+%if 0%{?sle_version} >= 150400
+find . -type f -name "ec2*" | xargs grep -l '/usr/bin/' | xargs sed -i 's/python3/python3.11/'
+%endif
 
 %build
+%if 0%{?sle_version} >= 150400
+%python311_pyproject_wheel
+%else
 python3 setup.py build
+%endif
 
 %install
+%if 0%{?sle_version} >= 150400
+%python311_pyproject_install
+%else
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
+%endif
 install -d -m 755 %{buildroot}/%{_mandir}/man1
 install -m 644 man/man1/* %{buildroot}/%{_mandir}/man1
 gzip %{buildroot}/%{_mandir}/man1/*
@@ -82,8 +105,13 @@ gzip %{buildroot}/%{_mandir}/man1/*
 %doc README.md
 %license LICENSE
 %{_mandir}/man*/*
+%if 0%{?sle_version} >= 150400
+%dir %{python311_sitelib}/ec2imgutils
+%{python311_sitelib}/*
+%else
 %dir %{python3_sitelib}/ec2imgutils
 %{python3_sitelib}/*
+%endif
 %{_bindir}/*
 
 %changelog

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 10.0.1
+current_version = 10.0.2
 commit = True
 tag = True
 

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -65,6 +65,8 @@ test_cli_args_data = [
       "--file",
       "/path/to/configuration/file",
       "--grub2",
+      "--imds-support",
+      "2.0",
       "--instance-id",
       "testInstanceId",
       "--machine",
@@ -149,6 +151,7 @@ def test_args(cli_args):
     assert parsed_args.waitCount == 8
     assert parsed_args.useSnap is True
     assert parsed_args.source == "testSource"
+    assert parsed_args.imdsVersion == "2.0"
 
 
 # --------------------------------------------------------------------
@@ -174,6 +177,8 @@ test_cli_args_data = [
       "--file",
       "/path/to/configuration/file",
       "--grub2",
+      "--imds-support",
+      "v2.0",
       "--machine",
       "x86_64",
       "--name",
@@ -196,7 +201,7 @@ test_cli_args_data = [
       "--ssh-timeout",
       "257",
       "--tpm-support",
-      "2.0",
+      "v2.0",
       "--type",
       "testType",
       "--user",
@@ -244,7 +249,7 @@ def test_args_check(cli_args):
     assert parsed_args.snapOnly is False
     assert parsed_args.sriov is True
     assert parsed_args.sshTimeout == 257
-    assert parsed_args.tpm == "2.0"
+    assert parsed_args.tpm == "v2.0"
     assert parsed_args.instType == "testType"
     assert parsed_args.sshUser == "testUser"
     assert parsed_args.usePrivateIP is True
@@ -253,6 +258,7 @@ def test_args_check(cli_args):
     assert parsed_args.vpcSubnetId == "testVpcSubnetId"
     assert parsed_args.waitCount == 8
     assert parsed_args.source == "testSource"
+    assert parsed_args.imdsVersion == "v2.0"
 
 
 # --------------------------------------------------------------------

--- a/tests/test_libec2uploadimg.py
+++ b/tests/test_libec2uploadimg.py
@@ -34,8 +34,8 @@ test_path = os.path.abspath(
 code_path = os.path.abspath('%s/../lib' % test_path)
 sys.path.insert(0, code_path)
 
-import ec2imgutils.ec2uploadimg as ec2upimg
-from ec2imgutils.ec2imgutilsExceptions import (
+import ec2imgutils.ec2uploadimg as ec2upimg  # noqa: E402
+from ec2imgutils.ec2imgutilsExceptions import (  # noqa: E402
     EC2UploadImgException
 )
 

--- a/tests/test_libec2uploadimg.py
+++ b/tests/test_libec2uploadimg.py
@@ -19,13 +19,22 @@
 # <http://www.gnu.org/licenses/>.
 #
 
+import inspect
 import logging
+import os
 import pytest
+import sys
+
 
 from unittest.mock import patch, MagicMock, call
 
-import ec2imgutils.ec2uploadimg as ec2upimg
+# Load the module from the source tree not the one on the system
+test_path = os.path.abspath(
+    os.path.dirname(inspect.getfile(inspect.currentframe())))
+code_path = os.path.abspath('%s/../lib' % test_path)
+sys.path.insert(0, code_path)
 
+import ec2imgutils.ec2uploadimg as ec2upimg
 from ec2imgutils.ec2imgutilsExceptions import (
     EC2UploadImgException
 )
@@ -2099,3 +2108,29 @@ def test_create_image_use_root_swap(
     show_progress_mock.assert_has_calls([call(), call()])
     detach_volume_mock.assert_has_calls([call(None)])
     attach_volume_mock.assert_has_calls([call('targetRootVol', None)])
+
+
+def test_invalid_tpm_value():
+    with pytest.raises(EC2UploadImgException) as e:
+        # Instance creation
+        ec2upimg.EC2ImageUploader(
+            access_key='',
+            wait_count=1,
+            log_callback=logger,
+            tpm_support='1'
+        )
+    msg = "tpm_support must be one of ['2.0', 'v2.0']"
+    assert msg in str(e)
+
+
+def test_invalid_imds_value():
+    with pytest.raises(EC2UploadImgException) as e:
+        # Instance creation
+        ec2upimg.EC2ImageUploader(
+            access_key='',
+            wait_count=1,
+            log_callback=logger,
+            imds_support='1'
+        )
+    msg = "imds_support must be one of ['2.0', 'v2.0']"
+    assert msg in str(e)


### PR DESCRIPTION
- Enable setting the IMDS version to use for instances via image attribute
- Update tests
  + Also update the libec2uploadimg test to enable direct execution in case pytest doesn't play well
- Switch the build for SLE 15 SP4 and later to use Python 3.11

This should **not** be merged with squash