### PR TITLE
Comply with the naming convention established for SUSE

### DIFF
--- a/python-ec2imgutils.spec
+++ b/python-ec2imgutils.spec
@@ -18,7 +18,7 @@
 
 %define upstream_name ec2imgutils
 
-Name:           python3-ec2imgutils
+Name:           python-ec2imgutils
 Version:        10.0.3
 Release:        0
 Summary:        Image management utilities for AWS EC2
@@ -26,7 +26,6 @@ License:        GPL-3.0+
 Group:          System/Management
 Url:            https://github.com/SUSE-Enceladus/ec2imgutils
 Source0:        %{upstream_name}-%{version}.tar.bz2
-%if 0%{?sle_version} >= 150400
 Requires:       python311
 Requires:       python311-boto3 >= 1.29.84
 Requires:       python311-dateutil
@@ -36,15 +35,6 @@ BuildRequires:  python311-dateutil
 BuildRequires:  python311-pip
 BuildRequires:  python311-setuptools
 BuildRequires:  python311-wheel
-%else
-Requires:       python3
-Requires:       python3-boto3 >= 1.29.84
-Requires:       python3-dateutil
-Requires:       python3-paramiko >= 2.2.0
-BuildRequires:  python3-boto3 >= 1.29.84
-BuildRequires:  python3-dateutil
-BuildRequires:  python3-setuptools
-%endif
 BuildRequires:  python-rpm-macros
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
@@ -71,6 +61,10 @@ Obsoletes:      python3-ec2publishimg < %{version}
 Provides:       python3-ec2uploadimg = %{version}
 Obsoletes:      python3-ec2uploadimg < %{version}
 
+# Package rename in SLE 15 SP4 to comply with new naming convention
+Provides:       python3-ec2imgutils = %{version}
+Obsoletes:      python3-ec2imgutils < %{version}
+
 %description
 A collection of image manipulation utilities for AWS EC2. These include:
 - ec2deprecateimg: Deprecates images by applying tags per convention
@@ -79,23 +73,13 @@ A collection of image manipulation utilities for AWS EC2. These include:
 
 %prep
 %setup -q -n %{upstream_name}-%{version}
-%if 0%{?sle_version} >= 150400
 find . -type f -name "ec2*" | xargs grep -l '/usr/bin/' | xargs sed -i 's/python3/python3.11/'
-%endif
 
 %build
-%if 0%{?sle_version} >= 150400
 %python311_pyproject_wheel
-%else
-python3 setup.py build
-%endif
 
 %install
-%if 0%{?sle_version} >= 150400
 %python311_pyproject_install
-%else
-python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
-%endif
 install -d -m 755 %{buildroot}/%{_mandir}/man1
 install -m 644 man/man1/* %{buildroot}/%{_mandir}/man1
 gzip %{buildroot}/%{_mandir}/man1/*
@@ -105,13 +89,8 @@ gzip %{buildroot}/%{_mandir}/man1/*
 %doc README.md
 %license LICENSE
 %{_mandir}/man*/*
-%if 0%{?sle_version} >= 150400
 %dir %{python311_sitelib}/ec2imgutils
 %{python311_sitelib}/*
-%else
-%dir %{python3_sitelib}/ec2imgutils
-%{python3_sitelib}/*
-%endif
 %{_bindir}/*
 
 %changelog


### PR DESCRIPTION
Only packages that build for Python 3.6 are supposed to be names with a python3 prefix. Everything else is supposed to be named with python as the prefix.