### PR TITLE
Create resources when is not configured

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -30,7 +30,7 @@ jobs:
 
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ A collection of utilities for image management in AWS EC2
 > pip install ec2imgutils
 ```
 
+## Test
+```
+> pyenv virtualenv 3.9.21 ec2imgutils
+> pyenv activate ec2imgutils
+> pip install -e .
+> pytest
+```
+
 ## Utilities
 
 ### ec2deprecateimg
@@ -122,7 +130,7 @@ follows:
 
 * Start an instance
 * Create a storage volume and attach it to the running instance
-* Create volume that will be the new root and attach it to the running 
+* Create volume that will be the new root and attach it to the running
   instance
 * Upload the image
 * Unpack the image and dump it to the new root volume

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -685,8 +685,11 @@ def get_ssh_user(args, config, region, logger):
 # ----------------------------------------------------------------------------
 def get_vpc_subnet_id(args, config, region, setup,  logger):
     """Function to get the vpn_subnet parameter"""
-    if args.vpcSubnetId:
-        return _vpc_subnet_id_with_logger(args.vpcSubnetId, logger)
+    vpc_subnet_id = args.vpcSubnetId
+
+    if vpc_subnet_id:
+        logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
+        return vpc_subnet_id
 
     if not (args.amiID or args.runningID):
         # Depending on instance type an instance may possibly only
@@ -701,13 +704,14 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
                 'subnet_id_%s' % region,
                 '--vpc-subnet-id'
             )
-            return _vpc_subnet_id_with_logger(vpc_subnet_id, logger)
         except Exception:
             pass
         try:
             # falls back to setup.create_vpc_subnet()
-            vpc_subnet_id = setup.create_vpc_subnet()
-            return _vpc_subnet_id_with_logger(vpc_subnet_id, logger)
+            vpc_subnet_id = vpc_subnet_id or setup.create_vpc_subnet()
+            logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
+            return vpc_subnet_id
+
         except Exception:
             msg = (
                 'Not using a subnet-id, none given on the '

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -727,9 +727,7 @@ def get_security_group_ids(
     security_group_ids = args.securityGroupIds
 
     if not security_group_ids and not args.runningID:
-        if not args.accountName:
-            security_group_ids = setup.create_security_group()
-        else:
+        if args.accountName:
             try:
                 security_group_ids = utils.get_from_config(
                     args.accountName,
@@ -769,6 +767,7 @@ def get_security_group_ids(
                 security_group_ids = setup.create_security_group(
                     vpc_id
                 )
+    security_group_ids = security_group_ids or setup.create_security_group()
     return security_group_ids
 
 

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -685,10 +685,7 @@ def get_ssh_user(args, config, region, logger):
 # ----------------------------------------------------------------------------
 def get_vpc_subnet_id(args, config, region, setup,  logger):
     """Function to get the vpn_subnet parameter"""
-    vpc_subnet_id = args.vpcSubnetId
-
-    if not vpc_subnet_id and not args.accountName:
-        vpc_subnet_id = setup.create_vpc_subnet()
+    vpc_subnet_id = args.vpcSubnetId or setup.create_vpc_subnet()
 
     if not vpc_subnet_id and not (args.amiID or args.runningID):
         # Depending on instance type an instance may possibly only

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -685,9 +685,10 @@ def get_ssh_user(args, config, region, logger):
 # ----------------------------------------------------------------------------
 def get_vpc_subnet_id(args, config, region, setup,  logger):
     """Function to get the vpn_subnet parameter"""
-    vpc_subnet_id = args.vpcSubnetId
+    if args.vpcSubnetId:
+        return _vpc_subnet_id_with_logger(args.vpcSubnetId, logger)
 
-    if not vpc_subnet_id and not (args.amiID or args.runningID):
+    if not (args.amiID or args.runningID):
         # Depending on instance type an instance may possibly only
         # launch inside a subnet. Look in the config for a subnet if
         # no subnet ID is given and the AMI to use was not
@@ -700,21 +701,25 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
                 'subnet_id_%s' % region,
                 '--vpc-subnet-id'
             )
+            return _vpc_subnet_id_with_logger(vpc_subnet_id, logger)
         except Exception:
+            pass
+        try:
             # falls back to setup.create_vpc_subnet()
+            vpc_subnet_id = setup.create_vpc_subnet()
+            return _vpc_subnet_id_with_logger(vpc_subnet_id, logger)
+        except Exception:
             msg = 'Not using a subnet-id, none given on the '
             msg += 'command line and none found in config for '
             msg += '"subnet_id_%s" value' % region
-            logger.error(msg)
-
-        try:
-            vpc_subnet_id = vpc_subnet_id or setup.create_vpc_subnet()
-        except Exception:
+            logger.info(msg)
             logger.error('Unable to create a VPC Subnet')
+            setup.clean_up()
             sys.exit(1)
 
-    if vpc_subnet_id:
-        logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
+
+def _vpc_subnet_id_with_logger(vpc_subnet_id, logger):
+    logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
     return vpc_subnet_id
 
 

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -686,9 +686,10 @@ def get_ssh_user(args, config, region, logger):
 def get_vpc_subnet_id(args, config, region, setup,  logger):
     """Function to get the vpn_subnet parameter"""
     vpc_subnet_id = args.vpcSubnetId
+    log_msg = 'Using VPC subnet: %s'
 
     if vpc_subnet_id:
-        logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
+        logger.debug(log_msg % vpc_subnet_id)
         return vpc_subnet_id
 
     if not (args.amiID or args.runningID):
@@ -709,7 +710,7 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
         try:
             # falls back to setup.create_vpc_subnet()
             vpc_subnet_id = vpc_subnet_id or setup.create_vpc_subnet()
-            logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
+            logger.debug(log_msg % vpc_subnet_id)
             return vpc_subnet_id
 
         except Exception:

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -724,11 +724,6 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
             sys.exit(1)
 
 
-def _vpc_subnet_id_with_logger(vpc_subnet_id, logger):
-    logger.debug('Using VPC subnet: %s' % vpc_subnet_id)
-    return vpc_subnet_id
-
-
 # ----------------------------------------------------------------------------
 def get_security_group_ids(
         args,

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -686,10 +686,10 @@ def get_ssh_user(args, config, region, logger):
 def get_vpc_subnet_id(args, config, region, setup,  logger):
     """Function to get the vpn_subnet parameter"""
     vpc_subnet_id = args.vpcSubnetId
-    log_msg = 'Using VPC subnet: %s'
+    base_log_msg = 'Using VPC subnet: %s'
 
     if vpc_subnet_id:
-        logger.debug(log_msg % vpc_subnet_id)
+        logger.debug(base_log_msg % vpc_subnet_id)
         return vpc_subnet_id
 
     if not (args.amiID or args.runningID):
@@ -710,17 +710,16 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
         try:
             # falls back to setup.create_vpc_subnet()
             vpc_subnet_id = vpc_subnet_id or setup.create_vpc_subnet()
-            logger.debug(log_msg % vpc_subnet_id)
+            logger.debug(base_log_msg % vpc_subnet_id)
             return vpc_subnet_id
-
         except Exception:
             msg = (
                 'Not using a subnet-id, none given on the '
                 'command line, none found in config for '
-                f'"subnet_id_{region}" value '
+                '"subnet_id_%s" value '
                 'and unable to create a VPC Subnet'
             )
-            logger.error(msg)
+            logger.error(msg % region)
             setup.clean_up()
             sys.exit(1)
 

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -711,7 +711,7 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
         except Exception:
             msg = 'Not using a subnet-id, none given on the '
             msg += 'command line, none found in config for '
-            msg += '"subnet_id_%s" value' % region
+            msg += '"subnet_id_%s" value ' % region
             msg += 'and unable to create a VPC Subnet'
             logger.error(msg)
             setup.clean_up()

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -709,10 +709,12 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
             vpc_subnet_id = setup.create_vpc_subnet()
             return _vpc_subnet_id_with_logger(vpc_subnet_id, logger)
         except Exception:
-            msg = 'Not using a subnet-id, none given on the '
-            msg += 'command line, none found in config for '
-            msg += '"subnet_id_%s" value ' % region
-            msg += 'and unable to create a VPC Subnet'
+            msg = (
+                'Not using a subnet-id, none given on the '
+                'command line, none found in config for '
+                f'"subnet_id_{region}" value '
+                'and unable to create a VPC Subnet'
+            )
             logger.error(msg)
             setup.clean_up()
             sys.exit(1)

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -710,10 +710,10 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
             return _vpc_subnet_id_with_logger(vpc_subnet_id, logger)
         except Exception:
             msg = 'Not using a subnet-id, none given on the '
-            msg += 'command line and none found in config for '
+            msg += 'command line, none found in config for '
             msg += '"subnet_id_%s" value' % region
+            msg += 'and unable to create a VPC Subnet'
             logger.error(msg)
-            logger.error('Unable to create a VPC Subnet')
             setup.clean_up()
             sys.exit(1)
 

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -685,7 +685,7 @@ def get_ssh_user(args, config, region, logger):
 # ----------------------------------------------------------------------------
 def get_vpc_subnet_id(args, config, region, setup,  logger):
     """Function to get the vpn_subnet parameter"""
-    vpc_subnet_id = args.vpcSubnetId or setup.create_vpc_subnet()
+    vpc_subnet_id = args.vpcSubnetId
 
     if not vpc_subnet_id and not (args.amiID or args.runningID):
         # Depending on instance type an instance may possibly only
@@ -701,10 +701,16 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
                 '--vpc-subnet-id'
             )
         except Exception:
+            # falls back to setup.create_vpc_subnet()
             msg = 'Not using a subnet-id, none given on the '
             msg += 'command line and none found in config for '
             msg += '"subnet_id_%s" value' % region
             logger.error(msg)
+
+        try:
+            vpc_subnet_id = vpc_subnet_id or setup.create_vpc_subnet()
+        except Exception:
+            logger.error('Unable to create a VPC Subnet')
             sys.exit(1)
 
     if vpc_subnet_id:

--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -712,7 +712,7 @@ def get_vpc_subnet_id(args, config, region, setup,  logger):
             msg = 'Not using a subnet-id, none given on the '
             msg += 'command line and none found in config for '
             msg += '"subnet_id_%s" value' % region
-            logger.info(msg)
+            logger.error(msg)
             logger.error('Unable to create a VPC Subnet')
             setup.clean_up()
             sys.exit(1)

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -990,11 +990,38 @@ def test_get_vpc_subnet_id(caplog):
     logger.setLevel(logging.INFO)
 
 
+def test_get_vpc_subnet_id_account_name(caplog):
+    global logger
+
+    logger.setLevel(logging.DEBUG)
+    setup = MagicMock()
+    setup.create_vpc_subnet.return_value = 'vpcSubnetId'
+
+    class Args:
+        accountName = 'testAccountName'
+        vpcSubnetId = None
+        amiID = None
+        runningID = None
+
+    myArgs = Args()
+    vpc_subnet_id = ec2uploadimg.get_vpc_subnet_id(
+        myArgs,
+        None,
+        "reg1",
+        setup,
+        logger
+    )
+    assert 'Using VPC subnet: vpcSubnetId' in caplog.text
+    assert 'vpcSubnetId' == vpc_subnet_id
+    logger.setLevel(logging.INFO)
+
+
 @patch('ec2uploadimg.utils.get_from_config')
 def test_get_vpc_subnet_id_exc(get_from_config_mock, caplog):
     global logger
 
     setup = MagicMock()
+    setup.create_vpc_subnet.return_value = ''
 
     def my_side_eff(a1, a2, a3, a4, a5):
         raise Exception('myexception')
@@ -1019,9 +1046,8 @@ def test_get_vpc_subnet_id_exc(get_from_config_mock, caplog):
     assert 'Not using a subnet-id, none given on the' in caplog.text
     assert excinfo.value.code == 1
 
-
 # --------------------------------------------------------------------
-# Tests for get_vpc_subnet_id functions
+# Tests for get_security_group_ids functions
 def test_get_security_group_ids(caplog):
     global logger
 
@@ -1278,7 +1304,9 @@ def test_get_uploader_exc2(EC2ImageUploader_mock, caplog):
 # --------------------------------------------------------------------
 # Tests for main
 @patch('ec2uploadimg.ec2upimg.EC2ImageUploader')
+@patch('ec2imgutils.ec2setup.EC2Setup.create_vpc_subnet')
 def test_main_happy_path_snapOnly(
+    create_vpc_subnet_mock,
     EC2ImageUploader_mock,
     caplog
 ):
@@ -1287,6 +1315,8 @@ def test_main_happy_path_snapOnly(
     ec2I = MagicMock()
     ec2I.create_snapshot.return_value = mySnapshot
     EC2ImageUploader_mock.return_value = ec2I
+
+    create_vpc_subnet_mock.return_value = 'subnetVPCValue'
 
     cli_args = [
         "--account",
@@ -1329,13 +1359,17 @@ def test_main_happy_path_snapOnly(
 
 
 @patch('ec2uploadimg.ec2upimg.EC2ImageUploader')
+@patch('ec2imgutils.ec2setup.EC2Setup.create_vpc_subnet')
 def test_main_happy_path_rootSwapMethod(
+    create_vpc_subnet_mock,
     EC2ImageUploader_mock,
     caplog
 ):
     ec2I = MagicMock()
     ec2I.create_image_use_root_swap.return_value = 'myAmi'
     EC2ImageUploader_mock.return_value = ec2I
+
+    create_vpc_subnet_mock.return_value = 'subnetVPCValue'
 
     cli_args = [
         "--account",
@@ -1378,13 +1412,17 @@ def test_main_happy_path_rootSwapMethod(
 
 
 @patch('ec2uploadimg.ec2upimg.EC2ImageUploader')
+@patch('ec2imgutils.ec2setup.EC2Setup.create_vpc_subnet')
 def test_main_happy_path_useSnap(
+    create_vpc_subnet_mock,
     EC2ImageUploader_mock,
     caplog
 ):
     ec2I = MagicMock()
     ec2I.create_image_from_snapshot.return_value = 'myAmi'
     EC2ImageUploader_mock.return_value = ec2I
+
+    create_vpc_subnet_mock.return_value = 'subnetVPCValue'
 
     cli_args = [
         "--account",
@@ -1427,13 +1465,17 @@ def test_main_happy_path_useSnap(
 
 
 @patch('ec2uploadimg.ec2upimg.EC2ImageUploader')
+@patch('ec2imgutils.ec2setup.EC2Setup.create_vpc_subnet')
 def test_main_happy_path_other(
+    create_vpc_subnet_mock,
     EC2ImageUploader_mock,
     caplog
 ):
     ec2I = MagicMock()
     ec2I.create_image.return_value = 'myAmi'
     EC2ImageUploader_mock.return_value = ec2I
+
+    create_vpc_subnet_mock.return_value = 'subnetVPCValue'
 
     cli_args = [
         "--account",

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1079,8 +1079,8 @@ def test_get_security_group_ids(caplog):
 def test_get_security_group_ids_accName(get_from_config_mock, caplog):
     global logger
 
-    # setup = MagicMock()
-    # setup.create_security_group.return_value = 'securityGroupId'
+    setup = MagicMock()
+    setup.create_security_group.return_value = None
     logger.setLevel(logging.DEBUG)
     get_from_config_mock.return_value = 'securityGroupId'
 
@@ -1098,7 +1098,7 @@ def test_get_security_group_ids_accName(get_from_config_mock, caplog):
         "reg1",
         None,
         None,
-        None,
+        setup,
         None,
         logger
     )

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1045,6 +1045,37 @@ def test_get_vpc_subnet_id_exc(get_from_config_mock, caplog):
 
 
 @patch('ec2uploadimg.utils.get_from_config')
+def test_get_vpc_subnet_id_create(get_from_config_mock, caplog):
+    global logger
+
+    setup = MagicMock()
+    setup.create_vpc_subnet.return_value = 'vpcSubnetId'
+
+    def my_side_eff(a1, a2, a3, a4, a5):
+        raise Exception('myexception')
+
+    get_from_config_mock.side_effect = my_side_eff
+
+    class Args:
+        accountName = 'testAccountName'
+        vpcSubnetId = None
+        amiID = None
+        runningID = None
+
+    myArgs = Args()
+    ec2uploadimg.get_vpc_subnet_id(
+        myArgs,
+        None,
+        "reg1",
+        setup,
+        logger
+    )
+
+    assert 'Not using a subnet-id, none given on the' in caplog.text
+    setup.create_vpc_subnet.assert_called_with()
+
+
+@patch('ec2uploadimg.utils.get_from_config')
 def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
     global logger
 

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1041,37 +1041,6 @@ def test_get_vpc_subnet_id_exc(get_from_config_mock, caplog):
         setup,
         logger
     )
-    assert 'Not using a subnet-id, none given on the' in caplog.text
-
-
-@patch('ec2uploadimg.utils.get_from_config')
-def test_get_vpc_subnet_id_create(get_from_config_mock, caplog):
-    global logger
-
-    setup = MagicMock()
-    setup.create_vpc_subnet.return_value = 'vpcSubnetId'
-
-    def my_side_eff(a1, a2, a3, a4, a5):
-        raise Exception('myexception')
-
-    get_from_config_mock.side_effect = my_side_eff
-
-    class Args:
-        accountName = 'testAccountName'
-        vpcSubnetId = None
-        amiID = None
-        runningID = None
-
-    myArgs = Args()
-    ec2uploadimg.get_vpc_subnet_id(
-        myArgs,
-        None,
-        "reg1",
-        setup,
-        logger
-    )
-
-    assert 'Not using a subnet-id, none given on the' in caplog.text
     setup.create_vpc_subnet.assert_called_with()
 
 
@@ -1105,6 +1074,7 @@ def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
         )
     assert 'Not using a subnet-id, none given on the' in caplog.text
     assert 'Unable to create a VPC Subnet' in caplog.text
+    setup.clean_up.assert_called_with()
     assert excinfo.value.code == 1
 
 

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1017,7 +1017,7 @@ def test_get_vpc_subnet_id_account_name(caplog):
 
 
 @patch('ec2uploadimg.utils.get_from_config')
-def test_get_vpc_subnet_id_exc(get_from_config_mock, caplog):
+def test_get_vpc_subnet_id_exc(get_from_config_mock):
     global logger
 
     setup = MagicMock()
@@ -1079,7 +1079,7 @@ def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
 
 # --------------------------------------------------------------------
 # Tests for get_security_group_ids functions
-def test_get_security_group_ids(caplog):
+def test_get_security_group_ids():
     global logger
 
     setup = MagicMock()

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1046,6 +1046,7 @@ def test_get_vpc_subnet_id_exc(get_from_config_mock, caplog):
     assert 'Not using a subnet-id, none given on the' in caplog.text
     assert excinfo.value.code == 1
 
+
 # --------------------------------------------------------------------
 # Tests for get_security_group_ids functions
 def test_get_security_group_ids(caplog):

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1072,7 +1072,17 @@ def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
             setup,
             logger
         )
-    assert 'Not using a subnet-id, none given on the' in caplog.text
+    # msg = 'Not using a subnet-id, none given on the '
+    # msg += 'command line, none found in config for '
+    # msg += '"subnet_id_%s" value ' % region
+    # msg += 'and unable to create a VPC Subnet'
+
+    error_message = 'Not using a subnet-id, none given on the '
+    error_message += 'command line, none found in config for '
+    error_message += '"subnet_id_reg1" value '
+    error_message += 'and unable to create a VPC Subnet'
+
+    assert error_message in caplog.text
     setup.clean_up.assert_called_with()
     assert excinfo.value.code == 1
 

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1073,7 +1073,6 @@ def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
             logger
         )
     assert 'Not using a subnet-id, none given on the' in caplog.text
-    assert 'Unable to create a VPC Subnet' in caplog.text
     setup.clean_up.assert_called_with()
     assert excinfo.value.code == 1
 

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1072,10 +1072,13 @@ def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
             setup,
             logger
         )
-    error_message = 'Not using a subnet-id, none given on the '
-    error_message += 'command line, none found in config for '
-    error_message += '"subnet_id_reg1" value '
-    error_message += 'and unable to create a VPC Subnet'
+
+    error_message = (
+        'Not using a subnet-id, none given on the '
+        'command line, none found in config for '
+        '"subnet_id_reg1" value '
+        'and unable to create a VPC Subnet'
+    )
 
     assert error_message in caplog.text
     setup.clean_up.assert_called_with()

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -1072,11 +1072,6 @@ def test_get_vpc_subnet_id_create_exc(get_from_config_mock, caplog):
             setup,
             logger
         )
-    # msg = 'Not using a subnet-id, none given on the '
-    # msg += 'command line, none found in config for '
-    # msg += '"subnet_id_%s" value ' % region
-    # msg += 'and unable to create a VPC Subnet'
-
     error_message = 'Not using a subnet-id, none given on the '
     error_message += 'command line, none found in config for '
     error_message += '"subnet_id_reg1" value '


### PR DESCRIPTION
When ec2uploadimg is used and no subnet or security-group are provided via config file nor command line options, the resources necessary to upload an image should be created instead of raising an exception and exit the program.