### PR TITLE
Fix spec filename in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ current_version = 10.0.3
 commit = True
 tag = True
 
-[bumpversion:file:python3-ec2imgutils.spec]
+[bumpversion:file:python-ec2imgutils.spec]
 
 [bumpversion:file:lib/ec2imgutils/VERSION]
 


### PR DESCRIPTION
During the process of version bumping we were receiving the error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'python3-ec2imgutils.spec'
``` 
The `setup.cfg` was referencing the spec filename as `python3-ec2imgutils.spec` and this was causing this error.