### PR TITLE
Fix make tar error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MANPATH=/usr/share/man
 dirs = lib man
 files = Makefile README.md LICENSE ec2deprecateimg ec2listimg ec2publishimg ec2removeimg ec2uploadimg setup.py requirements-dev.txt requirements.txt
 
-verSpec = $(shell rpm -q --specfile --qf '%{VERSION}' *.spec)
+verSpec = $(shell awk '/^Version:/ { print $$2 }' *.spec)
 verSrc = $(shell cat lib/ec2imgutils/VERSION)
 
 ifneq "$(verSpec)" "$(verSrc)"
@@ -13,7 +13,7 @@ $(error "Version mismatch, will not take any action")
 endif
 
 clean:
-	@find . -name "*.pyc" | xargs rm -f 
+	@find . -name "*.pyc" | xargs rm -f
 	@find . -name "__pycache__" | xargs rm -rf
 	@find . -name "*.cache" | xargs rm -rf
 	@find . -name "*.egg-info" | xargs rm -rf


### PR DESCRIPTION
There was an error when we were running `make tar`. 
```
$ make tar
error: line 36: Dependency tokens must begin with alpha-numeric, '_' or '/': BuildRequires:  %{python_module boto3 >= 1.29.84}
error: query of specfile python-ec2imgutils.spec failed, can't parse
Makefile:12: *** "Version mismatch, will not take any action".  Stop.
```