### PR TITLE
Sets a 300s timeout in the ssh channel for sftp uploads

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -254,6 +254,16 @@ def parse_args(args):
         metavar='SSH_TIME_OUT',
         type=int
     )
+    help_msg = 'Timeout value for inactivity in the channel used for the '
+    help_msg += 'image upload, default 900s (Optional)'
+    parser.add_argument(
+        '--channel-timeout',
+        default=900,
+        dest='channelTimeout',
+        help=help_msg,
+        metavar='CHANNEL_TIME_OUT',
+        type=int
+    )
     help_msg = 'The image supports NitroTPM, supported values 2.0/v2.0'
     help_msg += ' (Optional)'
     parser.add_argument(
@@ -920,6 +930,7 @@ def get_uploader(
                 ssh_key_pair_name=key_pair_name,
                 ssh_key_private_key_file=ssh_private_key_file,
                 ssh_timeout=args.sshTimeout,
+                channel_timeout=args.channelTimeout,
                 use_grub2=args.grub2,
                 use_private_ip=args.usePrivateIP,
                 vpc_subnet_id=vpc_subnet_id,

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import paramiko
+import socket
 import sys
 import threading
 import time
@@ -55,6 +56,7 @@ class EC2ImageUploader(EC2ImgUtils):
                  ssh_key_pair_name=None,
                  ssh_key_private_key_file=None,
                  ssh_timeout=300,
+                 channel_timeout=900,
                  use_grub2=False,
                  use_private_ip=False,
                  vpc_subnet_id='',
@@ -96,6 +98,7 @@ class EC2ImageUploader(EC2ImgUtils):
         self.ssh_key_pair_name = ssh_key_pair_name
         self.ssh_key_private_key_file = ssh_key_private_key_file
         self.ssh_timeout = ssh_timeout
+        self.channel_timeout = channel_timeout
         self.tpm = tpm_support
         self.use_grub2 = use_grub2
         self.use_private_ip = use_private_ip
@@ -971,13 +974,17 @@ class EC2ImageUploader(EC2ImgUtils):
         filename = source.split(os.sep)[-1]
         sftp = self.ssh_client.open_sftp()
         try:
-            sftp.get_channel().settimeout(self.ssh_timeout)
+            sftp.get_channel().settimeout(self.channel_timeout)
             self.log.debug('Uploading image file: {}'.format(source))
             sftp.put(source,
                      '%s/%s' % (target_dir, filename),
                      self._upload_progress)
             if self.log_level == logging.DEBUG:
                 print()
+        except socket.timeout:
+            self._clean_up()
+            error_msg = 'Channel timeout reached during upload process.'
+            raise EC2UploadImgException(error_msg)
         except Exception as e:
             self._clean_up()
             raise e

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -971,6 +971,7 @@ class EC2ImageUploader(EC2ImgUtils):
         filename = source.split(os.sep)[-1]
         sftp = self.ssh_client.open_sftp()
         try:
+            sftp.get_channel().settimeout(self.ssh_timeout)
             self.log.debug('Uploading image file: {}'.format(source))
             sftp.put(source,
                      '%s/%s' % (target_dir, filename),
@@ -980,6 +981,8 @@ class EC2ImageUploader(EC2ImgUtils):
         except Exception as e:
             self._clean_up()
             raise e
+        finally:
+            sftp.close()
 
         return filename
 

--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -180,6 +180,9 @@ driver has to be included in the image.
 .IP "--ssh-timeout SSH_TIME_OUT"
 Specifies the amount of time to wait in seconds to establish an SSH connection
 with the helper instance.
+.IP "--channel-timeout CHANNEL_TIME_OUT"
+Specifies the amount of time to wait in seconds to consider an upload
+unsuccessful per inactivity in the channel used.
 .IP "--tpm-support"
 Optionally specify the version of the TPM implementation the OS in the image
 supports. This option can only be used if

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -91,6 +91,8 @@ test_cli_args_data = [
       "--sriov-support",
       "--ssh-timeout",
       "257",
+      "--channel-timeout",
+      "834",
       "--tpm-support",
       "2.0",
       "--type",
@@ -142,6 +144,7 @@ def test_args(cli_args):
     assert parsed_args.snapOnly is True
     assert parsed_args.sriov is True
     assert parsed_args.sshTimeout == 257
+    assert parsed_args.channelTimeout == 834
     assert parsed_args.tpm == "2.0"
     assert parsed_args.instType == "testType"
     assert parsed_args.sshUser == "testUser"
@@ -202,6 +205,8 @@ test_cli_args_data = [
       "--sriov-support",
       "--ssh-timeout",
       "257",
+      "--channel-timeout",
+      "834",
       "--tpm-support",
       "v2.0",
       "--type",
@@ -252,6 +257,7 @@ def test_args_check(cli_args):
     assert parsed_args.snapOnly is False
     assert parsed_args.sriov is True
     assert parsed_args.sshTimeout == 257
+    assert parsed_args.channelTimeout == 834
     assert parsed_args.tpm == "v2.0"
     assert parsed_args.instType == "testType"
     assert parsed_args.sshUser == "testUser"

--- a/tests/test_libec2uploadimg.py
+++ b/tests/test_libec2uploadimg.py
@@ -23,6 +23,7 @@ import inspect
 import logging
 import os
 import pytest
+import socket
 import sys
 
 
@@ -1921,13 +1922,47 @@ def test_upload_image(
         call(),
         call.open_sftp(),
         call.open_sftp().get_channel(),
-        call.open_sftp().get_channel().settimeout(300),
+        call.open_sftp().get_channel().settimeout(900),
         call.open_sftp().put(
             '/test/imageName.img',
             'targetDir/imageName.img',
             upload_progress_mock
         )
     ])
+
+
+@patch('ec2imgutils.ec2uploadimg.EC2ImageUploader._upload_progress')
+def test_upload_image_socket_timeout(
+    upload_progress_mock,
+    caplog
+):
+    # Mocks
+    ssh_client_mock = MagicMock()
+    sftp_mock = MagicMock()
+    sftp_mock.put.side_effect = socket.timeout
+    ssh_client_mock.open_sftp.return_value = sftp_mock
+
+    # Instance creation
+    uploader = ec2upimg.EC2ImageUploader(
+        access_key='',
+        wait_count=1,
+        log_callback=logger
+    )
+    uploader.ssh_client = ssh_client_mock
+
+    with pytest.raises(EC2UploadImgException) as e:
+        uploader._upload_image('targetDir', '/test/imageName.img')
+
+    # assertions
+    msg = 'Channel timeout reached during upload process.'
+    assert msg in str(e)
+    ssh_client_mock.open_sftp.assert_called_once()
+    sftp_mock.get_channel().settimeout.assert_called_with(900)
+    sftp_mock.put.assert_called_with(
+        '/test/imageName.img',
+        'targetDir/imageName.img',
+        upload_progress_mock
+    )
 
 
 @patch('ec2imgutils.ec2uploadimg.EC2ImageUploader._clean_up')

--- a/tests/test_libec2uploadimg.py
+++ b/tests/test_libec2uploadimg.py
@@ -1920,6 +1920,8 @@ def test_upload_image(
     ssh_client_mock.assert_has_calls([
         call(),
         call.open_sftp(),
+        call.open_sftp().get_channel(),
+        call.open_sftp().get_channel().settimeout(300),
         call.open_sftp().put(
             '/test/imageName.img',
             'targetDir/imageName.img',


### PR DESCRIPTION
Avoid the uploads to get stuck if there's some issue with the network.