### PR TITLE
Support image tagging

### DIFF
--- a/ec2uploadimg
+++ b/ec2uploadimg
@@ -20,6 +20,7 @@
 
 import argparse
 import boto3
+import json
 import os
 import sys
 import signal
@@ -149,6 +150,16 @@ def parse_args(args):
         default=False,
         dest='grub2',
         help='The image uses the GRUB2 bootloader (Optional)'
+    )
+    help_msg = 'Provide valid json or a file name of a list of dicts '
+    help_msg += 'each dict having a "Key" and "Value" assignment '
+    help_msg += 'representing the key and value of a tag to be applied to '
+    help_msg += 'the image. (Optional)'
+    parser.add_argument(
+        '--image-tags',
+        dest='imageTags',
+        help=help_msg,
+        metavar='IMAGE_TAGS'
     )
     help_msg = 'Set the protocol version to be used when instances are '
     help_msg += 'launched from the image, supported values 2.0/v2.0. '
@@ -369,6 +380,53 @@ def check_required_arguments_and_constraints(args, logger):
     check_amiID_or_runningID_provided(args, logger)
     check_regions_parameter(args, logger)
     check_tpm_support_has_allowed_boot_options(args, logger)
+    check_image_tags(args, logger)
+
+
+# ----------------------------------------------------------------------------
+def check_image_tags(args, logger):
+    """This function determines if a file path is provided and if this
+    is the case loads the json from the file. Set the argument to the
+    resulting json object. If the json is provided as a string create the
+    json object"""
+    imgTags = None
+    error = ''
+    usr_img_tags = args.imageTags
+    if usr_img_tags:
+        if 'Key' in usr_img_tags and 'Value' in usr_img_tags:
+            try:
+                imgTags = json.loads(usr_img_tags)
+            except json.decoder.JSONDecodeError:
+                error = 'Decode'
+        # The given argument is not valid json it could be a file path with
+        # Key abd Value as part of the file name
+        if not imgTags:
+            if os.path.isfile(os.path.expanduser(usr_img_tags)):
+                try:
+                    imgTags = json.loads(open(usr_img_tags, 'r').read())
+                except PermissionError:
+                    error = 'File'
+                except json.decoder.JSONDecodeError:
+                    error = 'Decode'
+                except Exception:
+                    error = 'Unknown'
+            else:
+                error = 'File'
+
+        if not imgTags:
+            if error == 'File':
+                err_msg = 'Attempted to load file %s but the file could '
+                err_msg += 'not be found or read'
+                logger.error(err_msg % usr_img_tags)
+                sys.exit(1)
+            elif error == 'Decode':
+                logger.error('Provided json for tags is invalid')
+                sys.exit(1)
+            else:
+                logger.error('Unknown error processing image-tags argument')
+                sys.exit(1)
+
+    args.imageTags = imgTags
 
 
 # ----------------------------------------------------------------------------
@@ -928,7 +986,8 @@ def get_uploader(
                 log_callback=logger,
                 boot_mode=args.bootMode,
                 tpm_support=args.tpm,
-                imds_support=args.imdsVersion
+                imds_support=args.imdsVersion,
+                image_tags=args.imageTags
             )
             return uploader
     except EC2UploadImgException as e:

--- a/lib/ec2imgutils/ec2uploadimg.py
+++ b/lib/ec2imgutils/ec2uploadimg.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ec2uploadimg. If not, see <http://www.gnu.org/licenses/>.
 
+import botocore
 import json
 import logging
 import os
@@ -64,7 +65,8 @@ class EC2ImageUploader(EC2ImgUtils):
                  log_callback=None,
                  boot_mode=None,
                  tpm_support=None,
-                 imds_support=None
+                 imds_support=None,
+                 image_tags=None
                  ):
         EC2ImgUtils.__init__(
             self,
@@ -115,6 +117,7 @@ class EC2ImageUploader(EC2ImgUtils):
         self.ssh_client = None
         self.storage_volume_size = 2 * self.root_volume_size
         self.aborted = False
+        self.image_tags = image_tags
 
         if sriov_type and sriov_type != 'simple':
             raise EC2UploadImgException(
@@ -964,8 +967,25 @@ class EC2ImageUploader(EC2ImgUtils):
                 self.progress_timer.start()
 
     # ---------------------------------------------------------------------
+    def _tag_image(self, ami_id):
+        """Tag the image"""
+
+        if self.image_tags:
+            self.log.debug('Applying tags')
+            try:
+                self._connect().create_tags(
+                    Resources=[ami_id], Tags=self.image_tags
+                )
+            except botocore.exceptions.ParamValidationError:
+                msg = 'Tag appllication failed, please apply tags '
+                msg += 'manually via the aws tool or the web console. '
+                msg += 'Tag value validation failed.'
+                self.log.debug(msg)
+
+    # ---------------------------------------------------------------------
     def _upload_image(self, target_dir, source):
         """Upload the source file to the instance"""
+
         if self.aborted:
             return
         filename = source.split(os.sep)[-1]
@@ -1040,6 +1060,7 @@ class EC2ImageUploader(EC2ImgUtils):
         snapshot = self.create_snapshot(source)
 
         ami = self._register_image(snapshot)
+        self._tag_image(ami)
 
         return ami
 
@@ -1057,6 +1078,7 @@ class EC2ImageUploader(EC2ImgUtils):
 
         snapshot = response['Snapshots'][0]
         ami = self._register_image(snapshot)
+        self._tag_image(ami)
 
         return ami
 
@@ -1169,6 +1191,8 @@ class EC2ImageUploader(EC2ImgUtils):
             )
 
         self._clean_up()
+
+        self._tag_image(ami['ImageId'])
         return ami['ImageId']
 
     # ---------------------------------------------------------------------

--- a/man/man1/ec2uploadimg.1
+++ b/man/man1/ec2uploadimg.1
@@ -119,6 +119,16 @@ Setting this switch will select the
 value from the configuration file or will use the value given with
 .I --boot-kernel
 as the aki ID when a para virtual image is being registered.
+.IP "--image-tags"
+Optionally specify tags that should be applied to the image once it has been
+uploaded. The value for the argument is a valid json string representing
+a list of dictionaries where each dictionary specifies the key for the tag
+using the keyword "Key" and the value for this key with the keyword "Value".
+Alternatively the value of the argument may point to a file that specifies
+the same json construct. Example:
+.I '[{"Key":"1234", "Value":"5678"},{"Key":"Hello", "Value":"Goodbye"}]'
+Would lead to the uploaded image having 2 tags, one with the key "1234"
+and the other with the key "Hello". Each key would have the assigned values.
 .IP "--imds-support"
 Optionally specify the version for accessing the Instance MetaData Service
 (IMDS). The default is to access the IMDS using the version 1.0 implementation.

--- a/tests/test_ec2uploadimg.py
+++ b/tests/test_ec2uploadimg.py
@@ -218,6 +218,8 @@ test_cli_args_data = [
       "--use-enclave",
       "--wait-count",
       "8",
+      "--image-tags",
+      '[{"Key": "key", "Value": "value"}]',
       "testSource"]),
 ]
 
@@ -263,6 +265,7 @@ def test_args_check(cli_args):
     assert parsed_args.waitCount == 8
     assert parsed_args.source == "testSource"
     assert parsed_args.imdsVersion == "v2.0"
+    assert str(parsed_args.imageTags) == "[{'Key': 'key', 'Value': 'value'}]"
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Support images to be tagged on upload. It may be deirable to have images tagged for tracking purposes when instances are launched from those images. Support tagging on image upload rather than forcing the user to have a secondary operation.